### PR TITLE
feat: add ft pr command to checkout PRs into worktrees

### DIFF
--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -346,6 +346,80 @@ func TestRemoveAtShortcutAtDetachedHeadFails(t *testing.T) {
 	assertNoOutputOnError(t, stdout, stderr)
 }
 
+func TestPRCommandFetchesAndCreatesWorktree(t *testing.T) {
+	repoRoot, mainWorktreePath := setupCLIRepo(t)
+	t.Setenv(shell.EmitCDEnv, shell.EmitCDValue)
+
+	testutil.RunGit(t, "", "--git-dir", filepath.Join(repoRoot, ".git"), "update-ref", "refs/pull/123/head", "main")
+
+	stdout, stderr, err := runRootCommand(t, mainWorktreePath, "pr", "123")
+	if err != nil {
+		t.Fatalf("ft pr returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "Created worktree: pull/123 ->") {
+		t.Fatalf("ft pr output missing created message, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Switched to pull/123") {
+		t.Fatalf("ft pr output missing switched message, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, shell.CDMarkerPrefix) {
+		t.Fatalf("ft pr output missing cd marker, got: %q", stdout)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("ft pr stderr = %q, want empty", stderr)
+	}
+}
+
+func TestPRCommandReusesExistingWorktree(t *testing.T) {
+	repoRoot, mainWorktreePath := setupCLIRepo(t)
+	t.Setenv(shell.EmitCDEnv, shell.EmitCDValue)
+
+	pullBranchPath := filepath.Join(repoRoot, "pull-456")
+	testutil.RunGit(t, "", "--git-dir", filepath.Join(repoRoot, ".git"), "worktree", "add", "-b", "pull/456", pullBranchPath, "main")
+
+	testutil.RunGit(t, "", "--git-dir", filepath.Join(repoRoot, ".git"), "update-ref", "refs/pull/456/head", "pull/456")
+
+	stdout, stderr, err := runRootCommand(t, mainWorktreePath, "pr", "456")
+	if err != nil {
+		t.Fatalf("ft pr returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "Already exists: pull/456") {
+		t.Fatalf("ft pr output missing exists message, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Switched to pull/456") {
+		t.Fatalf("ft pr output missing switched message, got: %q", stdout)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("ft pr stderr = %q, want empty", stderr)
+	}
+}
+
+func TestPRCommandInvalidPRNumber(t *testing.T) {
+	_, mainWorktreePath := setupCLIRepo(t)
+
+	stdout, stderr, err := runRootCommand(t, mainWorktreePath, "pr", "abc")
+	if err == nil {
+		t.Fatalf("ft pr with invalid PR number expected error")
+	}
+	if !strings.Contains(err.Error(), "not a valid PR number") {
+		t.Fatalf("ft pr error = %q, expected invalid PR number message", err.Error())
+	}
+	assertNoOutputOnError(t, stdout, stderr)
+}
+
+func TestPRCommandNoPRArgument(t *testing.T) {
+	_, mainWorktreePath := setupCLIRepo(t)
+
+	stdout, stderr, err := runRootCommand(t, mainWorktreePath, "pr")
+	if err == nil {
+		t.Fatalf("ft pr without PR number expected error")
+	}
+	if !strings.Contains(err.Error(), "requires exactly one argument") {
+		t.Fatalf("ft pr error = %q, expected argument required message", err.Error())
+	}
+	assertNoOutputOnError(t, stdout, stderr)
+}
+
 func setupCLIRepo(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gbo-dev/feature-tree/internal/core"
+	"github.com/gbo-dev/feature-tree/internal/shell"
+)
+
+func newPRCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pr <num>",
+		Short: "Fetch and checkout a PR into a new worktree",
+		Long: `Fetch a pull request from origin and create a worktree for it.
+
+This command:
+1. Fetches the PR ref from origin (or uses cached ref)
+2. Ensures the local ref is up-to-date with the remote
+3. Creates a new worktree for the PR branch
+4. Switches to the new worktree
+
+The PR branch name will be in the format "pull/<num>".
+
+Examples:
+  ft pr 123         # Checkout PR #123 into a new worktree
+  ft pr 42          # Checkout PR #42`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("ft: requires exactly one argument: PR number")
+			}
+			_, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("ft: %q is not a valid PR number", args[0])
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prNum, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("ft: %q is not a valid PR number", args[0])
+			}
+
+			svc, err := core.NewService(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			result, err := svc.FetchAndCheckoutPR(prNum)
+			if err != nil {
+				return err
+			}
+
+			if result.Created {
+				fmt.Fprintf(cmd.OutOrStdout(), "Created worktree: %s -> %s\n", result.Branch, result.Path)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Already exists: %s (%s)\n", result.Branch, result.Path)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Switched to %s (%s)\n", result.Branch, result.Path)
+			shell.EmitCDOrWarning(result.Path, cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newCloneCmd())
 	cmd.AddCommand(newCreateCmd())
 	cmd.AddCommand(newSwitchCmd())
+	cmd.AddCommand(newPRCmd())
 	cmd.AddCommand(newIncludeCmd())
 	cmd.AddCommand(newSquashCmd())
 	cmd.AddCommand(newRemoveCmd())
@@ -40,6 +41,7 @@ Usage:
   ft clone <url> [dir]
   ft switch [--create] [--base <branch>] [branch]
   ft create [--all-branches] [--base <branch>] [branch]
+  ft pr <num>
   ft list
   ft remove [branch] [-f|--force-worktree] [-D|--force-branch] [--no-delete-branch]
   ft squash [--base <branch>]

--- a/internal/core/pr.go
+++ b/internal/core/pr.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+)
+
+type PRInfo struct {
+	Number     int
+	HeadRef    string
+	HeadSHA    string
+	BaseBranch string
+	BaseSHA    string
+	Title      string
+}
+
+func (s *Service) FetchAndCheckoutPR(prNumber int) (*PRResult, error) {
+	prInfo, err := s.GetPRInfo(prNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.ensureLocalRefUpdated(prInfo); err != nil {
+		return nil, err
+	}
+
+	worktrees, err := gitx.ListWorktrees(s.CommandCtx, s.Ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingPath := FindWorktreePath(worktrees, prInfo.HeadRef); existingPath != "" {
+		return &PRResult{
+			Number:  prInfo.Number,
+			Path:    existingPath,
+			Branch:  prInfo.HeadRef,
+			Created: false,
+		}, nil
+	}
+
+	result, err := s.CreateWorktree(prInfo.HeadRef, prInfo.BaseBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PRResult{
+		Number:  prInfo.Number,
+		Path:    result.Path,
+		Branch:  prInfo.HeadRef,
+		Created: result.Created,
+	}, nil
+}
+
+func (s *Service) GetPRInfo(prNumber int) (*PRInfo, error) {
+	refsToTry := []string{
+		fmt.Sprintf("refs/pull/%d/head", prNumber),
+		fmt.Sprintf("refs/pull/%d/merge", prNumber),
+	}
+
+	var headRef string
+	var headSHA string
+
+	for _, ref := range refsToTry {
+		stdout, _, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "rev-parse", "--verify", ref)
+		if runErr == nil && exitCode == 0 {
+			headRef = fmt.Sprintf("pull/%d", prNumber)
+			headSHA = strings.TrimSpace(stdout)
+			break
+		}
+	}
+
+	if headSHA == "" {
+		_, stderr, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "fetch", "origin", fmt.Sprintf("pull/%d/head:refs/pull/%d/head", prNumber, prNumber))
+		if err := gitx.CommandError("fetch PR ref", stderr, exitCode, runErr, "git fetch failed"); err != nil {
+			return nil, fmt.Errorf("ft: failed to fetch PR #%d: %w", prNumber, err)
+		}
+
+		headRef = fmt.Sprintf("pull/%d", prNumber)
+		stdout, stderr, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "rev-parse", "--verify", fmt.Sprintf("refs/pull/%d/head", prNumber))
+		if err := gitx.CommandError("resolve PR commit", stderr, exitCode, runErr, "git rev-parse failed"); err != nil {
+			return nil, fmt.Errorf("ft: failed to resolve PR #%d commit: %w", prNumber, err)
+		}
+		headSHA = strings.TrimSpace(stdout)
+	}
+
+	stdout, _, _, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "log", "--oneline", "-1", headSHA)
+	title := strings.TrimSpace(stdout)
+	if runErr != nil {
+		title = fmt.Sprintf("PR #%d", prNumber)
+	}
+
+	baseBranch := s.Ctx.DefaultBranch
+	baseSHA := ""
+
+	baseRefsToTry := []string{
+		fmt.Sprintf("refs/heads/%s", baseBranch),
+		fmt.Sprintf("refs/remotes/origin/%s", baseBranch),
+	}
+
+	for _, ref := range baseRefsToTry {
+		stdout, _, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "rev-parse", "--verify", ref)
+		if runErr == nil && exitCode == 0 {
+			baseSHA = strings.TrimSpace(stdout)
+			break
+		}
+	}
+
+	return &PRInfo{
+		Number:     prNumber,
+		HeadRef:    headRef,
+		HeadSHA:    headSHA,
+		BaseBranch: baseBranch,
+		BaseSHA:    baseSHA,
+		Title:      title,
+	}, nil
+}
+
+func (s *Service) ensureLocalRefUpdated(prInfo *PRInfo) error {
+	ref := fmt.Sprintf("refs/pull/%d/head", prInfo.Number)
+
+	stdout, _, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "rev-parse", "--verify", ref)
+	currentSHA := ""
+	if runErr == nil && exitCode == 0 {
+		currentSHA = strings.TrimSpace(stdout)
+	}
+
+	if currentSHA != "" && currentSHA == prInfo.HeadSHA {
+		return nil
+	}
+
+	_, stderr, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "fetch", "origin", fmt.Sprintf("pull/%d/head", prInfo.Number))
+	if err := gitx.CommandError("update PR ref", stderr, exitCode, runErr, "git fetch failed"); err != nil {
+		return fmt.Errorf("ft: failed to update PR #%d: %w", prInfo.Number, err)
+	}
+
+	return nil
+}
+
+func ParsePRNumber(input string) (int, error) {
+	prNum, err := strconv.Atoi(input)
+	if err != nil {
+		return 0, fmt.Errorf("ft: %q is not a valid PR number", input)
+	}
+	if prNum <= 0 {
+		return 0, fmt.Errorf("ft: PR number must be positive")
+	}
+	return prNum, nil
+}

--- a/internal/core/pr_test.go
+++ b/internal/core/pr_test.go
@@ -1,0 +1,337 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+	"github.com/gbo-dev/feature-tree/internal/testutil"
+)
+
+func TestParsePRNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{name: "valid positive", input: "123", want: 123, wantErr: false},
+		{name: "valid single digit", input: "1", want: 1, wantErr: false},
+		{name: "zero", input: "0", want: 0, wantErr: true},
+		{name: "negative", input: "-1", want: 0, wantErr: true},
+		{name: "non-numeric", input: "abc", want: 0, wantErr: true},
+		{name: "empty", input: "", want: 0, wantErr: true},
+		{name: "with spaces", input: " 123 ", want: 0, wantErr: true},
+		{name: "with leading zeros", input: "007", want: 7, wantErr: false},
+		{name: "large number", input: "2147483647", want: 2147483647, wantErr: false},
+		{name: "float-like", input: "1.5", want: 0, wantErr: true},
+		{name: "with letters", input: "123abc", want: 0, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePRNumber(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePRNumber(%q) expected error, got nil", tc.input)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ParsePRNumber(%q) unexpected error: %v", tc.input, err)
+				}
+				if got != tc.want {
+					t.Fatalf("ParsePRNumber(%q) = %d, want %d", tc.input, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPRInfoFetchesFromOrigin(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	featureBranch := "feature-to-pr"
+	featureBranchPath := filepath.Join(cloneResult.RepoRoot, featureBranch)
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "worktree", "add", "-b", featureBranch, featureBranchPath, cloneResult.DefaultBranch)
+
+	testutil.RunGit(t, featureBranchPath, "config", "user.name", "Test User")
+	testutil.RunGit(t, featureBranchPath, "config", "user.email", "test@example.com")
+
+	prFile := filepath.Join(featureBranchPath, "pr-file.txt")
+	if err := os.WriteFile(prFile, []byte("PR content\n"), 0o644); err != nil {
+		t.Fatalf("write pr file: %v", err)
+	}
+	testutil.RunGit(t, featureBranchPath, "add", "pr-file.txt")
+	testutil.RunGit(t, featureBranchPath, "commit", "-m", "PR commit")
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", "refs/pull/42/head", featureBranch)
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	prInfo, err := svc.GetPRInfo(42)
+	if err != nil {
+		t.Fatalf("GetPRInfo returned error: %v", err)
+	}
+	if prInfo.Number != 42 {
+		t.Fatalf("GetPRInfo Number = %d, want 42", prInfo.Number)
+	}
+	if prInfo.HeadRef != "pull/42" {
+		t.Fatalf("GetPRInfo HeadRef = %q, want %q", prInfo.HeadRef, "pull/42")
+	}
+	if prInfo.BaseBranch != cloneResult.DefaultBranch {
+		t.Fatalf("GetPRInfo BaseBranch = %q, want %q", prInfo.BaseBranch, cloneResult.DefaultBranch)
+	}
+}
+
+func TestFetchAndCheckoutPRCreatesWorktree(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	featureBranch := "feature-pr-test"
+	featureBranchPath := filepath.Join(cloneResult.RepoRoot, featureBranch)
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "worktree", "add", "-b", featureBranch, featureBranchPath, cloneResult.DefaultBranch)
+
+	testutil.RunGit(t, featureBranchPath, "config", "user.name", "Test User")
+	testutil.RunGit(t, featureBranchPath, "config", "user.email", "test@example.com")
+
+	prFile := filepath.Join(featureBranchPath, "pr-test-file.txt")
+	if err := os.WriteFile(prFile, []byte("PR test content\n"), 0o644); err != nil {
+		t.Fatalf("write pr test file: %v", err)
+	}
+	testutil.RunGit(t, featureBranchPath, "add", "pr-test-file.txt")
+	testutil.RunGit(t, featureBranchPath, "commit", "-m", "PR test commit")
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", "refs/pull/99/head", featureBranch)
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	result, err := svc.FetchAndCheckoutPR(99)
+	if err != nil {
+		t.Fatalf("FetchAndCheckoutPR returned error: %v", err)
+	}
+	if result.Number != 99 {
+		t.Fatalf("FetchAndCheckoutPR Number = %d, want 99", result.Number)
+	}
+	if result.Branch != "pull/99" {
+		t.Fatalf("FetchAndCheckoutPR Branch = %q, want %q", result.Branch, "pull/99")
+	}
+	if !result.Created {
+		t.Fatalf("FetchAndCheckoutPR Created = false, want true")
+	}
+
+	expectedPath := filepath.Join(cloneResult.RepoRoot, "pull-99")
+	if result.Path != expectedPath {
+		t.Fatalf("FetchAndCheckoutPR Path = %q, want %q", result.Path, expectedPath)
+	}
+}
+
+func TestFetchAndCheckoutPRReusesExistingWorktree(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	pullBranch := "pull/77"
+	pullBranchPath := filepath.Join(cloneResult.RepoRoot, "pull-77")
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "worktree", "add", "-b", pullBranch, pullBranchPath, cloneResult.DefaultBranch)
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", "refs/pull/77/head", pullBranch)
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	result, err := svc.FetchAndCheckoutPR(77)
+	if err != nil {
+		t.Fatalf("FetchAndCheckoutPR returned error: %v", err)
+	}
+	if result.Number != 77 {
+		t.Fatalf("FetchAndCheckoutPR Number = %d, want 77", result.Number)
+	}
+	if result.Branch != "pull/77" {
+		t.Fatalf("FetchAndCheckoutPR Branch = %q, want %q", result.Branch, "pull/77")
+	}
+	if result.Created {
+		t.Fatalf("FetchAndCheckoutPR Created = true, want false for existing worktree")
+	}
+
+	canonicalPath := testutil.CanonicalPath(t, result.Path)
+	canonicalWant := testutil.CanonicalPath(t, pullBranchPath)
+	if canonicalPath != canonicalWant {
+		t.Fatalf("FetchAndCheckoutPR Path = %q, want %q", canonicalPath, canonicalWant)
+	}
+}
+
+func TestGetPRInfoHandlesNonexistentPR(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	_, err = svc.GetPRInfo(999999)
+	if err == nil {
+		t.Fatalf("GetPRInfo expected error for nonexistent PR, got nil")
+	}
+}
+
+func TestEnsureLocalRefUpdatedRefreshesStaleRef(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	featureBranch := "feature-stale"
+	featureBranchPath := filepath.Join(cloneResult.RepoRoot, featureBranch)
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "worktree", "add", "-b", featureBranch, featureBranchPath, cloneResult.DefaultBranch)
+
+	testutil.RunGit(t, featureBranchPath, "config", "user.name", "Test User")
+	testutil.RunGit(t, featureBranchPath, "config", "user.email", "test@example.com")
+
+	prFile := filepath.Join(featureBranchPath, "stale-file.txt")
+	if err := os.WriteFile(prFile, []byte("stale content\n"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+	testutil.RunGit(t, featureBranchPath, "add", "stale-file.txt")
+	testutil.RunGit(t, featureBranchPath, "commit", "-m", "stale commit")
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", "refs/pull/55/head", featureBranch)
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	prInfo, err := svc.GetPRInfo(55)
+	if err != nil {
+		t.Fatalf("GetPRInfo returned error: %v", err)
+	}
+
+	err = svc.ensureLocalRefUpdated(prInfo)
+	if err != nil {
+		t.Fatalf("ensureLocalRefUpdated returned error: %v", err)
+	}
+
+	stdout, _, _, _ := gitx.RunGitCommon(context.Background(), svc.Ctx, "rev-parse", "--verify", fmt.Sprintf("refs/pull/%d/head", 55))
+	updatedSHA := strings.TrimSpace(stdout)
+	if updatedSHA != prInfo.HeadSHA {
+		t.Fatalf("ensureLocalRefUpdated: expected SHA %q, got %q", prInfo.HeadSHA, updatedSHA)
+	}
+}
+
+func TestFetchAndCheckoutPRNoOriginFails(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "remote", "remove", "origin")
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	_, err = svc.FetchAndCheckoutPR(42)
+	if err == nil {
+		t.Fatalf("FetchAndCheckoutPR expected error without origin, got nil")
+	}
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -28,6 +28,13 @@ type SwitchResult struct {
 	DidSwitch bool
 }
 
+type PRResult struct {
+	Number  int
+	Path    string
+	Branch  string
+	Created bool
+}
+
 type RemoveResult struct {
 	Branch            string
 	Path              string


### PR DESCRIPTION
Add 'ft pr <num>' command that mirrors 'gh pr checkout' by:
- Fetching PR refs from origin (pull/<num>/head or pull/<num>/merge)
- Ensuring local ref is up-to-date with remote (avoids stale refs)
- Creating a worktree for the PR branch (named pull/<num>)
- Switching to the new worktree with auto-cd support

The command handles edge cases:
- Reuses existing worktree if already present
- Re-fetches to update stale local refs before worktree creation
- Validates PR number is a positive integer
- Provides clear errors for missing origin remote or non-existent PRs

Includes unit tests and CLI integration tests.