### PR TITLE
feat: add preview window to ft switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then use `ft create <branch>` for any subsequent branches — it handles worktre
 | Command | Description |
 |---|---|
 | `ft clone <url> [dir]` | Clone a repo into bare-in-`.git` layout with an initial worktree |
-| `ft switch [branch]` | Switch to an existing worktree; opens fzf picker if no branch given |
+| `ft switch [branch]` | Switch to an existing worktree; opens fzf picker if no branch given (`tab`/`shift-tab` preview tabs in picker) |
 | `ft create [branch]` | Create a branch worktree; picker opens only with `--all-branches` and no branch |
 | `ft list` | List worktrees with status |
 | `ft remove [branch]` | Remove a worktree (and optionally its branch) |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then use `ft create <branch>` for any subsequent branches — it handles worktre
 | Command | Description |
 |---|---|
 | `ft clone <url> [dir]` | Clone a repo into bare-in-`.git` layout with an initial worktree |
-| `ft switch [branch]` | Switch to an existing worktree; opens fzf picker if no branch given (`tab`/`shift-tab` preview tabs in picker) |
+| `ft switch [branch]` | Switch to an existing worktree; opens fzf picker if no branch given (`tab`/`s-tab` preview tabs in picker) |
 | `ft create [branch]` | Create a branch worktree; picker opens only with `--all-branches` and no branch |
 | `ft list` | List worktrees with status |
 | `ft remove [branch]` | Remove a worktree (and optionally its branch) |
@@ -88,6 +88,15 @@ Run `ft help` for flag details.
 - the branch has local commits not pushed to its upstream
 
 Pass `-f` / `--force-worktree` to override. Pass `-D` / `--force-branch` to force-delete the branch regardless of merge status.
+
+## STATE values
+
+In list and picker views, `STATE` is shown as:
+- `clean` when there are no local changes
+- `+` for staged changes
+- `!` for unstaged changes
+- `?` for untracked files
+- combinations like `+!`, `!?`, or `+!?` when multiple apply
 
 ## `ft clone`
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -41,6 +41,41 @@ func TestInitCommandNoArgsEmitsNoStderr(t *testing.T) {
 	}
 }
 
+func TestRootCommandWithoutArgsShowsOverviewNotFullNotes(t *testing.T) {
+	stdout, stderr, err := runRootCommand(t, "")
+	if err != nil {
+		t.Fatalf("ft returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("ft stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "Available Commands:") {
+		t.Fatalf("ft stdout should include command list header, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "switch") {
+		t.Fatalf("ft stdout should include available commands, got: %q", stdout)
+	}
+	if strings.Contains(stdout, "Notes:") {
+		t.Fatalf("ft stdout should not include full notes, got: %q", stdout)
+	}
+}
+
+func TestRootHelpIncludesColoredNotes(t *testing.T) {
+	stdout, stderr, err := runRootCommand(t, "", "--help")
+	if err != nil {
+		t.Fatalf("ft --help returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("ft --help stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "Notes:") {
+		t.Fatalf("ft --help stdout missing notes, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "\x1b[") {
+		t.Fatalf("ft --help stdout should include ANSI styling, got: %q", stdout)
+	}
+}
+
 func TestCommandFlowCreateSwitchRemove(t *testing.T) {
 	repoRoot, mainWorktreePath := setupCLIRepo(t)
 	t.Setenv(shell.EmitCDEnv, shell.EmitCDValue)

--- a/internal/cli/pickerpreview.go
+++ b/internal/cli/pickerpreview.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const switchPreviewTabCount = 4
+
+const (
+	ansiReset         = "\x1b[0m"
+	ansiTabActiveBg   = "\x1b[48;2;26;46;44m"
+	ansiTabActiveFg   = "\x1b[38;2;244;237;224m"
+	ansiTabInactiveFg = "\x1b[38;5;244m"
+)
+
+var switchPreviewTabLabels = []string{"HEAD+-", "Commit log", "vs. default branch", "vs. upstream"}
+
+func newPickerPreviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "__picker-preview <cache-file>",
+		Hidden: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("ft: expected preview cache file path")
+			}
+			if strings.TrimSpace(args[0]) == "" {
+				return fmt.Errorf("ft: preview cache file path is empty")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := filepath.Abs(args[0])
+			if err != nil {
+				return fmt.Errorf("ft: resolve preview cache file path: %w", err)
+			}
+
+			data, err := os.ReadFile(resolved)
+			if err != nil {
+				return fmt.Errorf("ft: read preview cache file: %w", err)
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), string(data))
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newPickerPreviewStateCmd() *cobra.Command {
+	var stateFile string
+	var step int
+
+	cmd := &cobra.Command{
+		Use:    "__picker-preview-state",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(stateFile) == "" {
+				return fmt.Errorf("ft: state file is required")
+			}
+			if step == 0 {
+				return nil
+			}
+
+			current, err := readPreviewTabState(stateFile)
+			if err != nil {
+				return err
+			}
+
+			next := current + step
+			for next < 1 {
+				next += switchPreviewTabCount
+			}
+			for next > switchPreviewTabCount {
+				next -= switchPreviewTabCount
+			}
+
+			if err := os.WriteFile(stateFile, []byte(strconv.Itoa(next)), 0o600); err != nil {
+				return fmt.Errorf("ft: write preview tab state: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&stateFile, "state-file", "", "Path to preview tab state file")
+	cmd.Flags().IntVar(&step, "step", 0, "Tab step increment (1 or -1)")
+	return cmd
+}
+
+func newPickerPreviewTabCmd() *cobra.Command {
+	var stateFile string
+
+	cmd := &cobra.Command{
+		Use:    "__picker-preview-tab <tab1-file> <tab2-file> <tab3-file> <tab4-file>",
+		Hidden: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != switchPreviewTabCount {
+				return fmt.Errorf("ft: expected %d tab files", switchPreviewTabCount)
+			}
+			if strings.TrimSpace(stateFile) == "" {
+				return fmt.Errorf("ft: state file is required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tab, err := readPreviewTabState(stateFile)
+			if err != nil {
+				return err
+			}
+			if tab < 1 || tab > switchPreviewTabCount {
+				tab = 1
+			}
+
+			tabFile := args[tab-1]
+			resolved, err := filepath.Abs(tabFile)
+			if err != nil {
+				return fmt.Errorf("ft: resolve preview cache file path: %w", err)
+			}
+
+			data, err := os.ReadFile(resolved)
+			if err != nil {
+				return fmt.Errorf("ft: read preview cache file: %w", err)
+			}
+
+			header := renderPreviewHeaderLine(tab)
+			fmt.Fprint(cmd.OutOrStdout(), header+"\n"+string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&stateFile, "state-file", "", "Path to preview tab state file")
+	return cmd
+}
+
+func readPreviewTabState(stateFile string) (int, error) {
+	resolved, err := filepath.Abs(stateFile)
+	if err != nil {
+		return 0, fmt.Errorf("ft: resolve preview state path: %w", err)
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return 0, fmt.Errorf("ft: read preview tab state: %w", err)
+	}
+
+	tab, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("ft: parse preview tab state: %w", err)
+	}
+	if tab < 1 || tab > switchPreviewTabCount {
+		tab = 1
+	}
+	return tab, nil
+}
+
+func renderPreviewHeaderLine(activeTab int) string {
+	parts := make([]string, 0, len(switchPreviewTabLabels))
+	for idx, label := range switchPreviewTabLabels {
+		tab := idx + 1
+		padded := " " + label + " "
+		if tab == activeTab {
+			parts = append(parts, ansiTabActiveBg+ansiTabActiveFg+padded+ansiReset)
+		} else {
+			parts = append(parts, ansiTabInactiveFg+padded+ansiReset)
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cli/pickerpreview.go
+++ b/internal/cli/pickerpreview.go
@@ -7,19 +7,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gbo-dev/feature-tree/internal/textwidth"
+	"github.com/gbo-dev/feature-tree/internal/uiansi"
 	"github.com/spf13/cobra"
 )
 
 const switchPreviewTabCount = 4
 
-const (
-	ansiReset         = "\x1b[0m"
-	ansiTabActiveBg   = "\x1b[48;2;26;46;44m"
-	ansiTabActiveFg   = "\x1b[38;2;244;237;224m"
-	ansiTabInactiveFg = "\x1b[38;5;244m"
-)
-
-var switchPreviewTabLabels = []string{"HEAD+-", "Commit log", "vs. default branch", "vs. upstream"}
+var switchPreviewTabLabels = []string{"Overview", "Commit log", "vs. default", "vs. upstream"}
 
 func newPickerPreviewCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -161,14 +156,43 @@ func readPreviewTabState(stateFile string) (int, error) {
 
 func renderPreviewHeaderLine(activeTab int) string {
 	parts := make([]string, 0, len(switchPreviewTabLabels))
+	plainParts := make([]string, 0, len(switchPreviewTabLabels))
 	for idx, label := range switchPreviewTabLabels {
 		tab := idx + 1
 		padded := " " + label + " "
+		plainParts = append(plainParts, padded)
 		if tab == activeTab {
-			parts = append(parts, ansiTabActiveBg+ansiTabActiveFg+padded+ansiReset)
+			parts = append(parts, uiansi.TabActiveBg+uiansi.TabActiveFg+padded+uiansi.Reset)
 		} else {
-			parts = append(parts, ansiTabInactiveFg+padded+ansiReset)
+			parts = append(parts, uiansi.Grey+padded+uiansi.Reset)
 		}
 	}
-	return strings.Join(parts, " ")
+
+	tabsPlain := strings.Join(plainParts, " ")
+	tabsStyled := strings.Join(parts, " ")
+	hint := "[tab/s-tab]"
+	hintStyled := uiansi.InfoPurple + hint + uiansi.Reset
+
+	cols := previewWidthColumns()
+	if cols <= 0 {
+		return tabsStyled + "  " + hintStyled
+	}
+
+	padding := cols - textwidth.Width(tabsPlain) - textwidth.Width(hint)
+	if padding < 2 {
+		padding = 2
+	}
+	return tabsStyled + strings.Repeat(" ", padding) + hintStyled
+}
+
+func previewWidthColumns() int {
+	raw := strings.TrimSpace(os.Getenv("FZF_PREVIEW_COLUMNS"))
+	if raw == "" {
+		return 0
+	}
+	cols, err := strconv.Atoi(raw)
+	if err != nil || cols <= 0 {
+		return 0
+	}
+	return cols
 }

--- a/internal/cli/pickerpreview_test.go
+++ b/internal/cli/pickerpreview_test.go
@@ -79,8 +79,11 @@ func TestPickerPreviewTabCommandReadsCurrentTabFile(t *testing.T) {
 	if strings.TrimSpace(stderr) != "" {
 		t.Fatalf("__picker-preview-tab stderr = %q, want empty", stderr)
 	}
-	if !strings.Contains(stdout, "vs. default branch") {
+	if !strings.Contains(stdout, "vs. default") {
 		t.Fatalf("__picker-preview-tab stdout missing tab header labels: %q", stdout)
+	}
+	if !strings.Contains(stdout, "[tab/s-tab]") {
+		t.Fatalf("__picker-preview-tab stdout missing key hint: %q", stdout)
 	}
 	if !strings.Contains(stdout, "\x1b[48;2;26;46;44m") {
 		t.Fatalf("__picker-preview-tab stdout missing active-tab background color: %q", stdout)

--- a/internal/cli/pickerpreview_test.go
+++ b/internal/cli/pickerpreview_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPickerPreviewCommandReadsCacheFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "preview.txt")
+	if err := os.WriteFile(cacheFile, []byte("hello preview\n"), 0o600); err != nil {
+		t.Fatalf("write cache file: %v", err)
+	}
+
+	stdout, stderr, err := runRootCommand(t, "", "__picker-preview", cacheFile)
+	if err != nil {
+		t.Fatalf("__picker-preview returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("__picker-preview stderr = %q, want empty", stderr)
+	}
+	if stdout != "hello preview\n" {
+		t.Fatalf("__picker-preview stdout = %q, want %q", stdout, "hello preview\n")
+	}
+}
+
+func TestPickerPreviewStateCommandCyclesTabs(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "tab-state")
+	if err := os.WriteFile(stateFile, []byte("1"), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+
+	_, _, err := runRootCommand(t, "", "__picker-preview-state", "--state-file", stateFile, "--step", "1")
+	if err != nil {
+		t.Fatalf("__picker-preview-state returned error: %v", err)
+	}
+
+	out, readErr := os.ReadFile(stateFile)
+	if readErr != nil {
+		t.Fatalf("read state file: %v", readErr)
+	}
+	if strings.TrimSpace(string(out)) != "2" {
+		t.Fatalf("state file = %q, want %q", strings.TrimSpace(string(out)), "2")
+	}
+}
+
+func TestPickerPreviewTabCommandReadsCurrentTabFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "tab-state")
+	if err := os.WriteFile(stateFile, []byte("3"), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+
+	tab1 := filepath.Join(tmpDir, "tab1.txt")
+	tab2 := filepath.Join(tmpDir, "tab2.txt")
+	tab3 := filepath.Join(tmpDir, "tab3.txt")
+	tab4 := filepath.Join(tmpDir, "tab4.txt")
+
+	if err := os.WriteFile(tab1, []byte("one"), 0o600); err != nil {
+		t.Fatalf("write tab1: %v", err)
+	}
+	if err := os.WriteFile(tab2, []byte("two"), 0o600); err != nil {
+		t.Fatalf("write tab2: %v", err)
+	}
+	if err := os.WriteFile(tab3, []byte("three"), 0o600); err != nil {
+		t.Fatalf("write tab3: %v", err)
+	}
+	if err := os.WriteFile(tab4, []byte("four"), 0o600); err != nil {
+		t.Fatalf("write tab4: %v", err)
+	}
+
+	stdout, stderr, err := runRootCommand(t, "", "__picker-preview-tab", "--state-file", stateFile, tab1, tab2, tab3, tab4)
+	if err != nil {
+		t.Fatalf("__picker-preview-tab returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("__picker-preview-tab stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "vs. default branch") {
+		t.Fatalf("__picker-preview-tab stdout missing tab header labels: %q", stdout)
+	}
+	if !strings.Contains(stdout, "\x1b[48;2;26;46;44m") {
+		t.Fatalf("__picker-preview-tab stdout missing active-tab background color: %q", stdout)
+	}
+	if !strings.HasSuffix(stdout, "three") {
+		t.Fatalf("__picker-preview-tab stdout should end with selected tab content, got: %q", stdout)
+	}
+	if strings.Contains(stdout, "3/4") {
+		t.Fatalf("__picker-preview-tab should not show preview row counter, got: %q", stdout)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,8 +57,8 @@ Notes:
   - clone sets up bare-in-.git layout, resolves origin/HEAD, and creates the first worktree.
   - Uses include manifest from default branch worktree (default: .worktreeinclude).
   - list markers: @ is current branch worktree, ^ is default branch worktree.
-  - STATE symbols: + staged, ! unstaged, ? untracked; combinations (e.g. +!?) mean multiple states.
-  - switch without branch opens fzf picker when running in a TTY (preview tabs: tab/shift-tab).
+  - STATE shows clean or symbols: + staged, ! unstaged, ? untracked; combinations (e.g. +!?) mean multiple states.
+  - switch without branch opens fzf picker when running in a TTY (preview tabs: tab/s-tab).
   - create without branch requires an explicit name unless --all-branches is used.
   - create --all-branches without branch opens fzf picker when running in a TTY.
   - switch/create auto-cd when shell integration is active.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/gbo-dev/feature-tree/internal/uiansi"
 	"github.com/spf13/cobra"
 )
+
+const ansiBold = "\x1b[1m"
 
 func ExecuteContext(ctx context.Context) error {
 	root := newRootCmd()
@@ -17,6 +21,10 @@ func newRootCmd() *cobra.Command {
 		Short:         "feature-tree – lightweight git worktree helper",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderRootOverview(cmd)
+			return nil
+		},
 	}
 
 	cmd.AddCommand(newListCmd())
@@ -38,22 +46,22 @@ func newRootCmd() *cobra.Command {
 	return cmd
 }
 
-const helpTemplate = `ft (feature-tree) – lightweight git worktree helper
+var helpTemplate = fmt.Sprintf(`%s%sft%s (feature-tree) – lightweight git worktree helper
 
-Usage:
-  ft clone <url> [dir]
-  ft switch [--create] [--base <branch>] [branch]
-  ft create [--all-branches] [--base <branch>] [branch]
-  ft pr <num>
-  ft list
-  ft remove [branch] [-f|--force-worktree] [-D|--force-branch] [--no-delete-branch]
-  ft squash [--base <branch>]
-  ft copy-include [--from <branch>] [--to <branch>]
-  ft completion [bash|zsh]
-  ft init [bash|zsh]
-  ft help
+%sUsage:%s
+  %sft%s clone <url> [dir]
+  %sft%s switch [--create] [--base <branch>] [branch]
+  %sft%s create [--all-branches] [--base <branch>] [branch]
+  %sft%s pr <num>
+  %sft%s list
+  %sft%s remove [branch] [-f|--force-worktree] [-D|--force-branch] [--no-delete-branch]
+  %sft%s squash [--base <branch>]
+  %sft%s copy-include [--from <branch>] [--to <branch>]
+  %sft%s completion [bash|zsh]
+  %sft%s init [bash|zsh]
+  %sft%s help
 
-Notes:
+%sNotes:%s
   - clone sets up bare-in-.git layout, resolves origin/HEAD, and creates the first worktree.
   - Uses include manifest from default branch worktree (default: .worktreeinclude).
   - list markers: @ is current branch worktree, ^ is default branch worktree.
@@ -65,4 +73,46 @@ Notes:
   - Enable integration with: eval "$(ft init zsh)"
   - Tab completion includes branch/worktree names for switch/create and --base.
   - init prints the ft() wrapper for auto-cd; completion prints completion definitions only.
-`
+`,
+	ansiBold, uiansi.InfoPurple, uiansi.Reset,
+	uiansi.InfoPurple, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.Periwinkle, uiansi.Reset,
+	uiansi.InfoPurple, uiansi.Reset,
+)
+
+func renderRootOverview(cmd *cobra.Command) {
+	w := cmd.OutOrStdout()
+
+	fmt.Fprintf(w, "%s%sft%s (feature-tree) – lightweight git worktree helper\n\n", ansiBold, uiansi.InfoPurple, uiansi.Reset)
+	fmt.Fprintf(w, "%sUsage:%s\n", uiansi.InfoPurple, uiansi.Reset)
+	fmt.Fprintf(w, "  %sft%s <command> [flags]\n\n", uiansi.Periwinkle, uiansi.Reset)
+
+	visibleCommands := make([]*cobra.Command, 0, len(cmd.Commands()))
+	maxNameWidth := 0
+	for _, sub := range cmd.Commands() {
+		if !sub.IsAvailableCommand() || sub.Hidden {
+			continue
+		}
+		visibleCommands = append(visibleCommands, sub)
+		if n := len(sub.Name()); n > maxNameWidth {
+			maxNameWidth = n
+		}
+	}
+
+	fmt.Fprintf(w, "%sAvailable Commands:%s\n", uiansi.InfoPurple, uiansi.Reset)
+	for _, sub := range visibleCommands {
+		fmt.Fprintf(w, "  %s%-*s%s  %s\n", uiansi.Periwinkle, maxNameWidth, sub.Name(), uiansi.Reset, sub.Short)
+	}
+
+	fmt.Fprintf(w, "\nRun %sft --help%s for full details.\n", uiansi.Periwinkle, uiansi.Reset)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,9 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newRemoveCmd())
 	cmd.AddCommand(newCompletionCmd())
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newPickerPreviewCmd())
+	cmd.AddCommand(newPickerPreviewStateCmd())
+	cmd.AddCommand(newPickerPreviewTabCmd())
 
 	cmd.SetHelpTemplate(helpTemplate)
 
@@ -55,7 +58,7 @@ Notes:
   - Uses include manifest from default branch worktree (default: .worktreeinclude).
   - list markers: @ is current branch worktree, ^ is default branch worktree.
   - STATE symbols: + staged, ! unstaged, ? untracked; combinations (e.g. +!?) mean multiple states.
-  - switch without branch opens fzf picker when running in a TTY.
+  - switch without branch opens fzf picker when running in a TTY (preview tabs: tab/shift-tab).
   - create without branch requires an explicit name unless --all-branches is used.
   - create --all-branches without branch opens fzf picker when running in a TTY.
   - switch/create auto-cd when shell integration is active.

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -21,6 +21,14 @@ func newSwitchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "switch [branch]",
 		Short: "Switch to an existing worktree branch",
+		Long: `Switch to an existing worktree branch.
+
+Interactive picker notes:
+- STATE shows clean or combinations of +, !, ?
+- + means staged changes
+- ! means unstaged changes
+- ? means untracked files
+- Preview tabs: tab/s-tab`,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeSwitchBranches(cmd, args, toComplete)
 		},

--- a/internal/gitx/worktree.go
+++ b/internal/gitx/worktree.go
@@ -139,13 +139,10 @@ func DirtySymbols(commandCtx context.Context, path string) (string, error) {
 
 func DirtyState(symbols string) string {
 	symbols = strings.TrimSpace(symbols)
-	if symbols == "" || symbols == "?" {
-		return "dirty"
-	}
-	if symbols == "clean" {
+	if symbols == "" || symbols == "clean" {
 		return "clean"
 	}
-	return fmt.Sprintf("dirty (%s)", symbols)
+	return symbols
 }
 
 func BranchRelation(commandCtx context.Context, ctx *RepoContext, branch string) (string, error) {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"strings"
 
 	fzf "github.com/junegunn/fzf/src"
@@ -74,6 +76,7 @@ type pickerRow struct {
 	relation string
 	current  bool
 	marker   string
+	hidden   []string
 }
 
 type headerCol struct {
@@ -228,6 +231,16 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		return "", fmt.Errorf("no worktrees available")
 	}
 
+	previewCache, cleanupPreviewCache, cacheErr := buildSwitchPreviewCache(commandCtx, ctx, rows)
+	if cacheErr == nil {
+		defer cleanupPreviewCache()
+		for i := range rows {
+			if tabs, ok := previewCache.tabsByBranch[rows[i].branch]; ok {
+				rows[i].hidden = []string{tabs.headPath, tabs.logPath, tabs.defaultDiffPath, tabs.upstreamDiffPath}
+			}
+		}
+	}
+
 	l := fitListLayout(computeLayout(rows))
 	lines := buildFZFLines(rows, l)
 	header := pickerHeader(l.branchWidth, []headerCol{
@@ -238,10 +251,24 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		{colTitleCommit, l.commitWidth},
 	})
 	const promptColor = "#8787ff"
-	return pickBranch(lines, "switch> ",
-		"--color=prompt:"+promptColor,
-		"--header="+header,
-	)
+	extraArgs := []string{
+		"--color=prompt:" + promptColor,
+		"--header=" + header,
+	}
+	if cacheErr == nil {
+		nextTabCommand := switchPreviewStateCommand(previewCache.stateFile, 1)
+		prevTabCommand := switchPreviewStateCommand(previewCache.stateFile, -1)
+		renderCommand := switchPreviewRenderCommand(previewCache.stateFile)
+		extraArgs = append(extraArgs,
+			"--preview="+renderCommand,
+			"--preview-window=down,70%,wrap,border-top,~1,noinfo",
+			"--bind=tab:execute-silent("+nextTabCommand+")+refresh-preview",
+			"--bind=btab:execute-silent("+prevTabCommand+")+refresh-preview",
+			"--bind=shift-tab:execute-silent("+prevTabCommand+")+refresh-preview",
+		)
+	}
+
+	return pickBranch(lines, "switch> ", extraArgs...)
 }
 
 func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, currentBranch string, ctx *gitx.RepoContext, includeAllBranches bool) (string, error) {
@@ -413,7 +440,8 @@ func fzfBaseArgs() []string {
 		"--delimiter=\t",
 		"--with-nth=1",
 		"--layout=reverse",
-		"--height=~40%",
+		"--height=~100%",
+		"--min-height=26+",
 		"--border=sharp",
 		"--pointer=◆",
 		"--marker=>",
@@ -475,8 +503,8 @@ func runFZF(lines []string, prompt string, extraArgs ...string) (string, error) 
 	}
 }
 
-// buildFZFLines emits "display\tbranch". The hidden branch payload after the
-// tab is used by parseSelectedBranch to extract the raw selection.
+// buildFZFLines emits "display\tbranch[\thidden...]". The hidden payload fields
+// after the first tab are for preview and parseSelectedBranch ignores them.
 func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
@@ -520,7 +548,11 @@ func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 		}
 
 		display := prefix + branchField + strings.Join(parts, "  ")
-		lines = append(lines, strings.TrimRight(display, " ")+"\t"+row.branch)
+		payload := row.branch
+		if len(row.hidden) > 0 {
+			payload += "\t" + strings.Join(row.hidden, "\t")
+		}
+		lines = append(lines, strings.TrimRight(display, " ")+"\t"+payload)
 	}
 	return lines
 }
@@ -531,14 +563,34 @@ func parseSelectedBranch(selected string) (string, error) {
 		return "", ErrSelectionCancelled
 	}
 
-	if idx := strings.Index(selected, "\t"); idx >= 0 {
-		branch := strings.TrimSpace(selected[idx+1:])
+	if strings.Contains(selected, "\t") {
+		parts := strings.Split(selected, "\t")
+		if len(parts) < 2 {
+			return "", fmt.Errorf("could not extract branch from fzf output")
+		}
+		branch := strings.TrimSpace(parts[1])
 		if branch != "" {
 			return branch, nil
 		}
 	}
 
 	return "", fmt.Errorf("could not extract branch from fzf output")
+}
+
+func switchPreviewStateCommand(stateFile string, step int) string {
+	exe := "ft"
+	if resolved, err := os.Executable(); err == nil && strings.TrimSpace(resolved) != "" {
+		exe = resolved
+	}
+	return strconv.Quote(exe) + " __picker-preview-state --state-file " + strconv.Quote(stateFile) + " --step " + strconv.Itoa(step)
+}
+
+func switchPreviewRenderCommand(stateFile string) string {
+	exe := "ft"
+	if resolved, err := os.Executable(); err == nil && strings.TrimSpace(resolved) != "" {
+		exe = resolved
+	}
+	return strconv.Quote(exe) + " __picker-preview-tab --state-file " + strconv.Quote(stateFile) + " {3} {4} {5} {6}"
 }
 
 func PrintWorktreeList(commandCtx context.Context, entries []gitx.Worktree, currentBranch string, ctx *gitx.RepoContext, w io.Writer) error {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -13,18 +13,17 @@ import (
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/textwidth"
+	"github.com/gbo-dev/feature-tree/internal/uiansi"
 )
 
 var ErrSelectionCancelled = errors.New("selection cancelled")
 
-// Pastel ANSI 256-colour helpers (zero-width for layout purposes).
+const ansiBold = "\x1b[1m"
+
 const (
-	ansiReset      = "\x1b[0m"
-	ansiGrey       = "\x1b[38;5;244m" // muted grey – paths
-	ansiBold       = "\x1b[1m"        // bold
-	ansiGreen      = "\x1b[38;5;114m" // pastel green – current marker
-	ansiYellow     = "\x1b[38;5;228m" // pastel yellow – dirty state
-	ansiPeriwinkle = "\x1b[38;5;111m" // periwinkle – default branch marker
+	ansiPromptSwitch = "\x1b[38;2;135;135;255m"
+	ansiPromptCreate = "\x1b[38;2;127;212;255m"
+	ansiPromptRemove = "\x1b[38;2;255;143;143m"
 )
 
 // Column width caps in visible terminal columns (ANSI codes excluded).
@@ -32,8 +31,10 @@ const (
 	branchDisplayMax   = 30 // right-truncated with ellipsis suffix (preserves meaningful prefix)
 	pathDisplayMax     = 20 // right-truncated with ellipsis suffix (preserves relative-prefix context)
 	commitDisplayMax   = 72 // subject-only commit column (hash omitted)
-	listCommitMax      = 26 // list COMMIT needs to be narrower than fzf (max line len <= 105)
-	stateDisplayMax    = 11 // longest value: "dirty (+!?)" = 11 chars
+	pickerCommitMax    = 120
+	pickerBranchBonus  = 4
+	listCommitMax      = 26 // list HEAD needs to be narrower than fzf (max line len <= 105)
+	stateDisplayMax    = 5  // longest value: "+!?" = 3 chars
 	relationDisplayMax = 12 // longest typical value: "A: 99  B: 99" = 12 chars
 	listLineMaxWidth   = 145
 )
@@ -43,6 +44,7 @@ const (
 	colTitlePath     = "PATH"
 	colTitleState    = "STATE"
 	colTitleRelation = "RELATION"
+	colTitleHead     = "HEAD"
 	colTitleCommit   = "COMMIT"
 )
 
@@ -135,7 +137,10 @@ func computeLayout(rows []pickerRow) rowLayout {
 }
 
 func lineWidth(l rowLayout) int {
-	width := 2 + l.branchWidth + 2 + l.pathWidth
+	width := 2 + l.branchWidth
+	if l.pathWidth > 0 {
+		width += 2 + l.pathWidth
+	}
 	if l.stateWidth > 0 {
 		width += 2 + l.stateWidth
 	}
@@ -161,7 +166,7 @@ func reduceWidth(v *int, minWidth int, overflow int) int {
 
 // fitListLayout shrinks flexible columns until the rendered list row width is
 // <= listLineMaxWidth. Shrink order prioritizes preserving branch/state context:
-// PATH -> COMMIT -> RELATION -> BRANCH -> STATE.
+// PATH -> HEAD -> RELATION -> BRANCH -> STATE.
 func fitListLayout(l rowLayout) rowLayout {
 	overflow := lineWidth(l) - listLineMaxWidth
 	if overflow <= 0 {
@@ -182,6 +187,61 @@ func capListCommitWidth(l rowLayout) rowLayout {
 		l.commitWidth = listCommitMax
 	}
 	return l
+}
+
+func maxBranchWidth(rows []pickerRow) int {
+	w := branchColMinWidth
+	for _, row := range rows {
+		if n := textwidth.Width(row.branch); n > w {
+			w = n
+		}
+	}
+	return w
+}
+
+func maxCommitWidth(rows []pickerRow) int {
+	w := 0
+	for _, row := range rows {
+		if s := row.commit.Display(pickerCommitMax); s != "" {
+			if n := textwidth.Width(s); n > w {
+				w = n
+			}
+		}
+	}
+	if w > 0 && w < colWidthCommit {
+		w = colWidthCommit
+	}
+	return w
+}
+
+func expandBranchCommitLayout(rows []pickerRow, l rowLayout) rowLayout {
+	spare := listLineMaxWidth - lineWidth(l)
+	if spare <= 0 {
+		return l
+	}
+
+	branchTarget := min(maxBranchWidth(rows), l.branchWidth+pickerBranchBonus)
+	if branchTarget > l.branchWidth {
+		add := min(branchTarget-l.branchWidth, spare)
+		l.branchWidth += add
+		spare -= add
+	}
+
+	if spare <= 0 {
+		return l
+	}
+
+	commitTarget := maxCommitWidth(rows)
+	if commitTarget > l.commitWidth {
+		add := min(commitTarget-l.commitWidth, spare)
+		l.commitWidth += add
+	}
+
+	return l
+}
+
+func promptLabel(name string, color string) string {
+	return color + name + uiansi.Reset + "> "
 }
 
 func currentWorktreePath(entries []gitx.Worktree, currentBranch string) string {
@@ -241,18 +301,18 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		}
 	}
 
-	l := fitListLayout(computeLayout(rows))
+	l := computeLayout(rows)
+	l.pathWidth = 0
+	l = fitListLayout(l)
+	l = expandBranchCommitLayout(rows, l)
 	lines := buildFZFLines(rows, l)
 	header := pickerHeader(l.branchWidth, []headerCol{
 		{colTitleBranch, 0},
-		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleCommit, l.commitWidth},
+		{colTitleHead, l.commitWidth},
 	})
-	const promptColor = "#8787ff"
 	extraArgs := []string{
-		"--color=prompt:" + promptColor,
 		"--header=" + header,
 	}
 	if cacheErr == nil {
@@ -265,10 +325,12 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 			"--bind=tab:execute-silent("+nextTabCommand+")+refresh-preview",
 			"--bind=btab:execute-silent("+prevTabCommand+")+refresh-preview",
 			"--bind=shift-tab:execute-silent("+prevTabCommand+")+refresh-preview",
+			"--bind=right:execute-silent("+nextTabCommand+")+refresh-preview",
+			"--bind=left:execute-silent("+prevTabCommand+")+refresh-preview",
 		)
 	}
 
-	return pickBranch(lines, "switch> ", extraArgs...)
+	return pickBranch(lines, promptLabel("switch", ansiPromptSwitch), extraArgs...)
 }
 
 func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, currentBranch string, ctx *gitx.RepoContext, includeAllBranches bool) (string, error) {
@@ -331,18 +393,18 @@ func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		return "", fmt.Errorf("no branches available")
 	}
 
-	l := fitListLayout(computeLayout(rows))
+	l := computeLayout(rows)
+	l.pathWidth = 0
+	l = fitListLayout(l)
+	l = expandBranchCommitLayout(rows, l)
 	lines := buildFZFLines(rows, l)
 	header := pickerHeader(l.branchWidth, []headerCol{
 		{colTitleBranch, 0},
-		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
 		{colTitleCommit, l.commitWidth},
 	})
-	const promptColor = "#7fd4ff"
-	return pickBranch(lines, "create> ",
-		"--color=prompt:"+promptColor,
+	return pickBranch(lines, promptLabel("create", ansiPromptCreate),
 		"--header="+header,
 	)
 }
@@ -396,11 +458,9 @@ func PickRemoveBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleCommit, l.commitWidth},
+		{colTitleHead, l.commitWidth},
 	})
-	const promptColor = "#ff8f8f"
-	return pickBranch(lines, "remove> ",
-		"--color=prompt:"+promptColor,
+	return pickBranch(lines, promptLabel("remove", ansiPromptRemove),
 		"--header="+header,
 	)
 }
@@ -409,7 +469,7 @@ func pickerHeader(branchWidth int, cols []headerCol) string {
 	branchTitle := cols[0].title
 	pad := branchWidth - len(branchTitle) + 2
 
-	line := ansiGrey + ansiBold + "  " + branchTitle + strings.Repeat(" ", pad)
+	line := uiansi.Grey + ansiBold + "  " + branchTitle + strings.Repeat(" ", pad)
 	for _, col := range cols[1:] {
 		if col.width > len(col.title) {
 			line += col.title + strings.Repeat(" ", col.width-len(col.title)) + "  "
@@ -417,7 +477,7 @@ func pickerHeader(branchWidth int, cols []headerCol) string {
 			line += col.title + "  "
 		}
 	}
-	return strings.TrimRight(line, " ") + ansiReset
+	return strings.TrimRight(line, " ") + uiansi.Reset
 }
 
 func pickBranch(lines []string, prompt string, extraArgs ...string) (string, error) {
@@ -450,8 +510,8 @@ func fzfBaseArgs() []string {
 		"--scrollbar=│",
 		"--info=right",
 		"--color=fg:-1,fg+:#f4ede0:regular,bg:-1,bg+:#1a2e2c",
-		"--color=hl:#48b08f,hl+:#6ce4be,info:#8788b0,marker:#00a6ff",
-		"--color=prompt:#00d6ba,spinner:#a2b9b9,pointer:#5e7eff,header:#87afaf",
+		"--color=hl:#48b08f,hl+:#6ce4be,info:" + uiansi.InfoPurpleHex + ",marker:#00a6ff",
+		"--color=prompt:-1,spinner:#a2b9b9,pointer:#5e7eff,header:#87afaf",
 		"--color=gutter:-1,border:#202020,label:#aeaeae,query:#d9d9d9:regular",
 	}
 }
@@ -511,9 +571,9 @@ func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 		var prefix string
 		switch {
 		case row.current:
-			prefix = ansiGreen + "@ " + ansiReset
+			prefix = uiansi.Green + "@ " + uiansi.Reset
 		case row.marker == "^":
-			prefix = ansiPeriwinkle + "^ " + ansiReset
+			prefix = uiansi.Periwinkle + "^ " + uiansi.Reset
 		default:
 			prefix = "  "
 		}
@@ -523,14 +583,16 @@ func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 
 		var parts []string
 
-		rendered := truncatePath(row.path, l.pathWidth)
-		parts = append(parts, ansiGrey+rendered+ansiReset+strings.Repeat(" ", l.pathWidth-textwidth.Width(rendered)))
+		if l.pathWidth > 0 {
+			rendered := truncatePath(row.path, l.pathWidth)
+			parts = append(parts, uiansi.Grey+rendered+uiansi.Reset+strings.Repeat(" ", l.pathWidth-textwidth.Width(rendered)))
+		}
 
 		if l.stateWidth > 0 && row.state != "" {
 			st := truncateCell(row.state, l.stateWidth)
 			pad := strings.Repeat(" ", l.stateWidth-textwidth.Width(st))
-			if strings.HasPrefix(row.state, "dirty") {
-				parts = append(parts, ansiYellow+st+ansiReset+pad)
+			if row.state != "clean" {
+				parts = append(parts, uiansi.Yellow+st+uiansi.Reset+pad)
 			} else {
 				parts = append(parts, st+pad)
 			}
@@ -538,12 +600,12 @@ func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 
 		if l.relationWidth > 0 && row.relation != "" {
 			rel := truncateCell(row.relation, l.relationWidth)
-			parts = append(parts, ansiGrey+rel+ansiReset+strings.Repeat(" ", l.relationWidth-textwidth.Width(rel)))
+			parts = append(parts, uiansi.Grey+rel+uiansi.Reset+strings.Repeat(" ", l.relationWidth-textwidth.Width(rel)))
 		}
 
 		if l.commitWidth > 0 {
 			if s := row.commit.Display(l.commitWidth); s != "" {
-				parts = append(parts, ansiGrey+s+ansiReset+strings.Repeat(" ", l.commitWidth-textwidth.Width(s)))
+				parts = append(parts, uiansi.Grey+s+uiansi.Reset+strings.Repeat(" ", l.commitWidth-textwidth.Width(s)))
 			}
 		}
 
@@ -636,7 +698,7 @@ func PrintWorktreeList(commandCtx context.Context, entries []gitx.Worktree, curr
 		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleCommit, l.commitWidth},
+		{colTitleHead, l.commitWidth},
 	})
 	fmt.Fprintln(w, header)
 

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -44,7 +44,6 @@ const (
 	colTitlePath     = "PATH"
 	colTitleState    = "STATE"
 	colTitleRelation = "RELATION"
-	colTitleHead     = "HEAD"
 	colTitleCommit   = "COMMIT"
 )
 
@@ -310,7 +309,7 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		{colTitleBranch, 0},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleHead, l.commitWidth},
+		{colTitleCommit, l.commitWidth},
 	})
 	extraArgs := []string{
 		"--header=" + header,
@@ -458,7 +457,7 @@ func PickRemoveBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleHead, l.commitWidth},
+		{colTitleCommit, l.commitWidth},
 	})
 	return pickBranch(lines, promptLabel("remove", ansiPromptRemove),
 		"--header="+header,
@@ -698,7 +697,7 @@ func PrintWorktreeList(commandCtx context.Context, entries []gitx.Worktree, curr
 		{colTitlePath, l.pathWidth},
 		{colTitleState, l.stateWidth},
 		{colTitleRelation, l.relationWidth},
-		{colTitleHead, l.commitWidth},
+		{colTitleCommit, l.commitWidth},
 	})
 	fmt.Fprintln(w, header)
 

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -17,6 +17,16 @@ func TestParseSelectedBranch(t *testing.T) {
 	}
 }
 
+func TestParseSelectedBranchIgnoresExtendedHiddenPayload(t *testing.T) {
+	branch, err := parseSelectedBranch("display\tfeature/test\t/tmp/head.txt\t/tmp/log.txt")
+	if err != nil {
+		t.Fatalf("parseSelectedBranch returned error: %v", err)
+	}
+	if branch != "feature/test" {
+		t.Fatalf("parseSelectedBranch = %q, want %q", branch, "feature/test")
+	}
+}
+
 func TestParseSelectedBranchRejectsMissingPayload(t *testing.T) {
 	_, err := parseSelectedBranch("display only")
 	if err == nil {
@@ -43,6 +53,28 @@ func TestBuildFZFLinesEmitsHiddenBranchPayload(t *testing.T) {
 	}
 	if !strings.HasSuffix(lines[0], "\tfeature/demo") {
 		t.Fatalf("buildFZFLines output missing hidden payload: %q", lines[0])
+	}
+}
+
+func TestBuildFZFLinesAppendsHiddenFields(t *testing.T) {
+	rows := []pickerRow{
+		{
+			branch:   "feature/demo",
+			commit:   gitx.CommitInfo{Hash: "abcd", Subject: "demo subject"},
+			path:     "../feature-demo",
+			state:    "clean",
+			relation: "A: 1 B: 0",
+			hidden:   []string{"/tmp/head.txt", "/tmp/log.txt"},
+		},
+	}
+
+	layout := computeLayout(rows)
+	lines := buildFZFLines(rows, layout)
+	if len(lines) != 1 {
+		t.Fatalf("buildFZFLines len = %d, want 1", len(lines))
+	}
+	if !strings.HasSuffix(lines[0], "\tfeature/demo\t/tmp/head.txt\t/tmp/log.txt") {
+		t.Fatalf("buildFZFLines output missing appended hidden fields: %q", lines[0])
 	}
 }
 

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -1,0 +1,477 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+)
+
+const (
+	maxSwitchPreviewWorkers = 6
+	switchLogLimit          = 30
+	ansiDiffRed             = "\x1b[38;5;203m"
+)
+
+type switchPreviewTabPaths struct {
+	headPath         string
+	logPath          string
+	defaultDiffPath  string
+	upstreamDiffPath string
+}
+
+type switchPreviewBuildJob struct {
+	index int
+	row   pickerRow
+}
+
+type switchPreviewBuildResult struct {
+	branch string
+	paths  switchPreviewTabPaths
+	err    error
+}
+
+type switchPreviewCache struct {
+	tabsByBranch map[string]switchPreviewTabPaths
+	stateFile    string
+}
+
+func buildSwitchPreviewCache(commandCtx context.Context, repoCtx *gitx.RepoContext, rows []pickerRow) (*switchPreviewCache, func(), error) {
+	cleanup := func() {}
+	if len(rows) == 0 {
+		return &switchPreviewCache{tabsByBranch: map[string]switchPreviewTabPaths{}}, cleanup, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ft-switch-preview-")
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("create switch preview cache dir: %w", err)
+	}
+
+	stateFile := filepath.Join(tmpDir, "tab-state")
+	if writeErr := os.WriteFile(stateFile, []byte("1"), 0o600); writeErr != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, cleanup, fmt.Errorf("create switch preview state file: %w", writeErr)
+	}
+
+	cleanup = func() {
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	workers := min(maxSwitchPreviewWorkers, len(rows))
+	if workers < 1 {
+		workers = 1
+	}
+
+	jobs := make(chan switchPreviewBuildJob)
+	results := make(chan switchPreviewBuildResult, len(rows))
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				paths, rowErr := buildSwitchPreviewRowCache(commandCtx, repoCtx, tmpDir, job)
+				results <- switchPreviewBuildResult{branch: job.row.branch, paths: paths, err: rowErr}
+			}
+		}()
+	}
+
+	go func() {
+		for idx, row := range rows {
+			jobs <- switchPreviewBuildJob{index: idx, row: row}
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+
+	cache := make(map[string]switchPreviewTabPaths, len(rows))
+	for result := range results {
+		if result.err != nil {
+			cleanup()
+			return nil, func() {}, result.err
+		}
+		cache[result.branch] = result.paths
+	}
+
+	return &switchPreviewCache{tabsByBranch: cache, stateFile: stateFile}, cleanup, nil
+}
+
+func buildSwitchPreviewRowCache(commandCtx context.Context, repoCtx *gitx.RepoContext, tmpDir string, job switchPreviewBuildJob) (switchPreviewTabPaths, error) {
+	headContent := renderSwitchHeadTab(job.row)
+	logContent := renderSwitchLogTab(commandCtx, repoCtx, job.row.branch)
+	defaultDiffContent := renderSwitchDefaultDiffTab(commandCtx, repoCtx, job.row.branch)
+	upstreamDiffContent := renderSwitchUpstreamDiffTab(commandCtx, repoCtx, job.row.branch)
+
+	prefix := fmt.Sprintf("b%03d", job.index)
+	headPath, err := writeSwitchPreviewFile(tmpDir, prefix+"-head.txt", headContent)
+	if err != nil {
+		return switchPreviewTabPaths{}, err
+	}
+	logPath, err := writeSwitchPreviewFile(tmpDir, prefix+"-log.txt", logContent)
+	if err != nil {
+		return switchPreviewTabPaths{}, err
+	}
+	defaultDiffPath, err := writeSwitchPreviewFile(tmpDir, prefix+"-main.txt", defaultDiffContent)
+	if err != nil {
+		return switchPreviewTabPaths{}, err
+	}
+	upstreamDiffPath, err := writeSwitchPreviewFile(tmpDir, prefix+"-upstream.txt", upstreamDiffContent)
+	if err != nil {
+		return switchPreviewTabPaths{}, err
+	}
+
+	return switchPreviewTabPaths{
+		headPath:         headPath,
+		logPath:          logPath,
+		defaultDiffPath:  defaultDiffPath,
+		upstreamDiffPath: upstreamDiffPath,
+	}, nil
+}
+
+func writeSwitchPreviewFile(tmpDir string, fileName string, content string) (string, error) {
+	fullPath := filepath.Join(tmpDir, fileName)
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("write switch preview cache %q: %w", fileName, err)
+	}
+	return fullPath, nil
+}
+
+func renderSwitchHeadTab(row pickerRow) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString("Path:   ")
+	b.WriteString(row.path)
+	b.WriteString("\n")
+	b.WriteString("State:  ")
+	b.WriteString(row.state)
+	b.WriteString("\n")
+	b.WriteString("Main:   ")
+	b.WriteString(row.relation)
+	b.WriteString("\n")
+	if strings.TrimSpace(row.commit.Hash) != "" && strings.TrimSpace(row.commit.Subject) != "" {
+		b.WriteString("HEAD:   ")
+		b.WriteString(row.commit.Hash)
+		b.WriteString(" ")
+		b.WriteString(row.commit.Subject)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	if row.state == "clean" {
+		b.WriteString(row.branch)
+		b.WriteString(" has no uncommitted changes.\n")
+	} else {
+		b.WriteString(row.branch)
+		b.WriteString(" has uncommitted changes (")
+		b.WriteString(row.state)
+		b.WriteString(").\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderSwitchLogTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) string {
+	var b strings.Builder
+	b.WriteString("\n")
+
+	stdout, stderr, exitCode, runErr := gitx.RunGitCommon(
+		commandCtx,
+		repoCtx,
+		"log",
+		"-n",
+		strconv.Itoa(switchLogLimit),
+		"--date=relative",
+		"--format=%H%x09%h%x09%ar%x09%s",
+		"--numstat",
+		branch,
+	)
+	if err := gitx.CommandError(fmt.Sprintf("read commit log for %q", branch), stderr, exitCode, runErr, "git log failed"); err != nil {
+		b.WriteString("Preview unavailable: ")
+		b.WriteString(err.Error())
+		b.WriteString("\n")
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	entries := parseSwitchLogEntries(stdout)
+	if len(entries) == 0 {
+		b.WriteString("No commits found.\n")
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	b.WriteString(renderSwitchLogTable(entries))
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderSwitchLogTable(entries []switchLogEntry) string {
+	var b strings.Builder
+	b.WriteString(ansiGrey + "HASH     DIFF         AGE          MESSAGE" + ansiReset + "\n")
+	for _, entry := range entries {
+		hash := fmt.Sprintf("%-7s", entry.shortHash)
+		diff := fmt.Sprintf("+%d -%d", entry.added, entry.deleted)
+		b.WriteString(ansiGrey + hash + ansiReset)
+		b.WriteString("  ")
+		b.WriteString(ansiGreen + "+" + strconv.Itoa(entry.added) + ansiReset)
+		b.WriteString(" ")
+		b.WriteString(ansiDiffRed + "-" + strconv.Itoa(entry.deleted) + ansiReset)
+		if pad := 11 - len(diff); pad > 0 {
+			b.WriteString(strings.Repeat(" ", pad))
+		}
+		b.WriteString("  ")
+		b.WriteString(ansiGrey + fmt.Sprintf("%-12s", entry.age) + ansiReset)
+		b.WriteString(" ")
+		b.WriteString(entry.subject)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderSwitchDefaultDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) string {
+	defaultBranch := repoCtx.DefaultBranch
+	if strings.TrimSpace(defaultBranch) == "" {
+		defaultBranch = "main"
+	}
+	return renderSwitchDiffTab(commandCtx, repoCtx, branch, defaultBranch, "default branch")
+}
+
+func renderSwitchUpstreamDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) string {
+	upstream, err := branchUpstream(commandCtx, repoCtx, branch)
+	if err != nil {
+		return "Diff vs upstream\n----------------\nPreview unavailable: " + err.Error()
+	}
+	if strings.TrimSpace(upstream) == "" {
+		return "Diff vs upstream\n----------------\nBranch has no upstream tracking branch."
+	}
+	return renderSwitchDiffTab(commandCtx, repoCtx, branch, upstream, "upstream")
+}
+
+func renderSwitchDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string, againstRef string, refLabel string) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString("Branch: ")
+	b.WriteString(branch)
+	b.WriteString("\n")
+	b.WriteString("Compare: ")
+	b.WriteString(againstRef)
+	b.WriteString("...")
+	b.WriteString(branch)
+	b.WriteString("\n\n")
+
+	stdout, stderr, exitCode, runErr := gitx.RunGitCommon(
+		commandCtx,
+		repoCtx,
+		"diff",
+		"--stat",
+		"--stat-width=100",
+		"--stat-name-width=56",
+		"--stat-graph-width=16",
+		againstRef+"..."+branch,
+	)
+	if err := gitx.CommandError(fmt.Sprintf("render diff for %q against %q", branch, againstRef), stderr, exitCode, runErr, "git diff failed"); err != nil {
+		b.WriteString("Preview unavailable: ")
+		b.WriteString(err.Error())
+		b.WriteString("\n")
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	if strings.TrimSpace(stdout) == "" {
+		b.WriteString("No diff between ")
+		b.WriteString(branch)
+		b.WriteString(" and ")
+		b.WriteString(refLabel)
+		b.WriteString(" (")
+		b.WriteString(againstRef)
+		b.WriteString(").\n")
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	b.WriteString(colorizeDiffStat(stdout))
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func colorizeDiffStat(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimRight(line, "\r")
+		if strings.Contains(trimmed, "|") {
+			lines[i] = colorizeDiffStatLine(trimmed)
+			continue
+		}
+		if strings.Contains(trimmed, " files changed") || strings.Contains(trimmed, " file changed") {
+			lines[i] = colorizeSummaryLine(trimmed)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func colorizeDiffStatLine(line string) string {
+	parts := strings.SplitN(line, "|", 2)
+	if len(parts) != 2 {
+		return line
+	}
+	left := strings.TrimRight(parts[0], " ")
+	right := strings.TrimSpace(parts[1])
+
+	rightFields := strings.Fields(right)
+	if len(rightFields) < 2 {
+		return line
+	}
+
+	changed := rightFields[0]
+	graph := strings.Join(rightFields[1:], " ")
+	graphColored := strings.ReplaceAll(graph, "+", ansiGreen+"+"+ansiReset)
+	graphColored = strings.ReplaceAll(graphColored, "-", ansiDiffRed+"-"+ansiReset)
+
+	return fmt.Sprintf("%s%-56s%s | %2s %s", ansiGrey, left, ansiReset, changed, graphColored)
+}
+
+func colorizeSummaryLine(line string) string {
+	fields := strings.Split(line, ",")
+	for i, segment := range fields {
+		segment = strings.TrimSpace(segment)
+		if strings.Contains(segment, "insertion") {
+			segment = strings.ReplaceAll(segment, "(", "")
+			segment = strings.ReplaceAll(segment, ")", "")
+			fields[i] = ansiGreen + segment + ansiReset
+			continue
+		}
+		if strings.Contains(segment, "deletion") {
+			segment = strings.ReplaceAll(segment, "(", "")
+			segment = strings.ReplaceAll(segment, ")", "")
+			fields[i] = ansiDiffRed + segment + ansiReset
+			continue
+		}
+		fields[i] = ansiGrey + segment + ansiReset
+	}
+	return strings.Join(fields, ", ")
+}
+
+func branchUpstream(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) (string, error) {
+	stdout, stderr, exitCode, runErr := gitx.RunGitCommon(commandCtx, repoCtx, "for-each-ref", "--format=%(upstream:short)", "refs/heads/"+branch)
+	if err := gitx.CommandError(fmt.Sprintf("resolve upstream for %q", branch), stderr, exitCode, runErr, "git for-each-ref failed"); err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line, nil
+		}
+	}
+	return "", nil
+}
+
+type switchLogEntry struct {
+	fullHash  string
+	shortHash string
+	age       string
+	subject   string
+	added     int
+	deleted   int
+}
+
+func parseSwitchLogEntries(stdout string) []switchLogEntry {
+	entries := make([]switchLogEntry, 0, switchLogLimit)
+	var current *switchLogEntry
+
+	flush := func() {
+		if current != nil {
+			entries = append(entries, *current)
+			current = nil
+		}
+	}
+
+	for _, rawLine := range strings.Split(stdout, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if fullHash, shortHash, age, subject, ok := parseSwitchLogHeader(line); ok {
+			flush()
+			current = &switchLogEntry{
+				fullHash:  fullHash,
+				shortHash: shortHash,
+				age:       age,
+				subject:   subject,
+			}
+			continue
+		}
+
+		if current == nil {
+			continue
+		}
+
+		added, deleted, ok := parseSwitchNumstatLine(line)
+		if !ok {
+			continue
+		}
+		current.added += added
+		current.deleted += deleted
+	}
+
+	flush()
+	return entries
+}
+
+func parseSwitchLogHeader(line string) (fullHash string, shortHash string, age string, subject string, ok bool) {
+	parts := strings.SplitN(line, "\t", 4)
+	if len(parts) != 4 {
+		return "", "", "", "", false
+	}
+	fullHash = strings.TrimSpace(parts[0])
+	if !looksLikeFullCommitHash(fullHash) {
+		return "", "", "", "", false
+	}
+	shortHash = strings.TrimSpace(parts[1])
+	age = strings.TrimSpace(parts[2])
+	subject = strings.TrimSpace(parts[3])
+	if shortHash == "" || age == "" || subject == "" {
+		return "", "", "", "", false
+	}
+	return fullHash, shortHash, age, subject, true
+}
+
+func parseSwitchNumstatLine(line string) (added int, deleted int, ok bool) {
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) != 3 {
+		return 0, 0, false
+	}
+
+	addedVal := 0
+	if parts[0] != "-" {
+		n, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, false
+		}
+		addedVal = n
+	}
+
+	deletedVal := 0
+	if parts[1] != "-" {
+		n, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, 0, false
+		}
+		deletedVal = n
+	}
+
+	return addedVal, deletedVal, true
+}
+
+func looksLikeFullCommitHash(hash string) bool {
+	if len(hash) != 40 {
+		return false
+	}
+	for _, r := range hash {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -10,12 +10,14 @@ import (
 	"sync"
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
+	"github.com/gbo-dev/feature-tree/internal/textwidth"
 	"github.com/gbo-dev/feature-tree/internal/uiansi"
 )
 
 const (
 	maxSwitchPreviewWorkers = 6
 	switchLogLimit          = 30
+	switchLogAgeWidth       = 12
 )
 
 type switchPreviewTabPaths struct {
@@ -233,7 +235,12 @@ func renderSwitchLogTable(entries []switchLogEntry) string {
 			b.WriteString(strings.Repeat(" ", pad))
 		}
 		b.WriteString("  ")
-		b.WriteString(uiansi.Grey + fmt.Sprintf("%-12s", entry.age) + uiansi.Reset)
+		b.WriteString(uiansi.Grey)
+		b.WriteString(entry.age)
+		if pad := switchLogAgeWidth - textwidth.Width(entry.age); pad > 0 {
+			b.WriteString(strings.Repeat(" ", pad))
+		}
+		b.WriteString(uiansi.Reset)
 		b.WriteString(" ")
 		b.WriteString(uiansi.Grey)
 		b.WriteString(entry.subject)
@@ -446,12 +453,55 @@ func parseSwitchLogHeader(line string) (fullHash string, shortHash string, age s
 		return "", "", "", "", false
 	}
 	shortHash = strings.TrimSpace(parts[1])
-	age = strings.TrimSpace(parts[2])
+	age = compactRelativeAge(strings.TrimSpace(parts[2]))
 	subject = strings.TrimSpace(parts[3])
 	if shortHash == "" || age == "" || subject == "" {
 		return "", "", "", "", false
 	}
 	return fullHash, shortHash, age, subject, true
+}
+
+func compactRelativeAge(age string) string {
+	age = strings.TrimSpace(age)
+	if age == "" {
+		return age
+	}
+
+	replacements := []struct {
+		from string
+		to   string
+	}{
+		{"about an ", "1 "},
+		{"about a ", "1 "},
+		{"an ", "1 "},
+		{"a ", "1 "},
+		{" seconds ago", " sec ago"},
+		{" second ago", " sec ago"},
+		{" minutes ago", " min ago"},
+		{" minute ago", " min ago"},
+		{" hours ago", " hr ago"},
+		{" hour ago", " hr ago"},
+		{" days ago", " day ago"},
+		{" day ago", " day ago"},
+		{" weeks ago", " wk ago"},
+		{" week ago", " wk ago"},
+		{" months ago", " mo ago"},
+		{" month ago", " mo ago"},
+		{" years ago", " yr ago"},
+		{" year ago", " yr ago"},
+	}
+
+	for _, replacement := range replacements {
+		age = strings.Replace(age, replacement.from, replacement.to, 1)
+	}
+
+	if textwidth.Width(age) > switchLogAgeWidth && strings.HasSuffix(age, " ago") {
+		age = strings.TrimSuffix(age, " ago")
+	}
+	if textwidth.Width(age) > switchLogAgeWidth {
+		age = textwidth.Truncate(age, switchLogAgeWidth)
+	}
+	return age
 }
 
 func parseSwitchNumstatLine(line string) (added int, deleted int, ok bool) {

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
+	"github.com/gbo-dev/feature-tree/internal/uiansi"
 )
 
 const (
 	maxSwitchPreviewWorkers = 6
 	switchLogLimit          = 30
-	ansiDiffRed             = "\x1b[38;5;203m"
 )
 
 type switchPreviewTabPaths struct {
@@ -146,33 +146,43 @@ func writeSwitchPreviewFile(tmpDir string, fileName string, content string) (str
 func renderSwitchHeadTab(row pickerRow) string {
 	var b strings.Builder
 	b.WriteString("\n")
-	b.WriteString("Path:   ")
-	b.WriteString(row.path)
-	b.WriteString("\n")
-	b.WriteString("State:  ")
-	b.WriteString(row.state)
-	b.WriteString("\n")
-	b.WriteString("Main:   ")
-	b.WriteString(row.relation)
-	b.WriteString("\n")
-	if strings.TrimSpace(row.commit.Hash) != "" && strings.TrimSpace(row.commit.Subject) != "" {
-		b.WriteString("HEAD:   ")
-		b.WriteString(row.commit.Hash)
-		b.WriteString(" ")
-		b.WriteString(row.commit.Subject)
-		b.WriteString("\n")
+	writeSwitchHeadField(&b, "PATH", row.path, uiansi.Grey)
+	stateColor := ""
+	if row.state != "clean" {
+		stateColor = uiansi.Yellow
 	}
-	b.WriteString("\n")
-	if row.state == "clean" {
-		b.WriteString(row.branch)
-		b.WriteString(" has no uncommitted changes.\n")
-	} else {
-		b.WriteString(row.branch)
-		b.WriteString(" has uncommitted changes (")
-		b.WriteString(row.state)
-		b.WriteString(").\n")
+	writeSwitchHeadField(&b, "STATE", row.state, stateColor)
+	writeSwitchHeadField(&b, "VS. MAIN", row.relation, uiansi.Grey)
+	if strings.TrimSpace(row.commit.Hash) != "" && strings.TrimSpace(row.commit.Subject) != "" {
+		writeSwitchHeadCommitField(&b, row.commit.Hash, row.commit.Subject)
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func writeSwitchHeadField(b *strings.Builder, label string, value string, valueColor string) {
+	b.WriteString(uiansi.InfoPurple)
+	b.WriteString(fmt.Sprintf("%-11s", label+":"))
+	b.WriteString(uiansi.Reset)
+	if valueColor != "" {
+		b.WriteString(valueColor)
+	}
+	b.WriteString(value)
+	if valueColor != "" {
+		b.WriteString(uiansi.Reset)
+	}
+	b.WriteString("\n")
+}
+
+func writeSwitchHeadCommitField(b *strings.Builder, hash string, subject string) {
+	b.WriteString(uiansi.InfoPurple)
+	b.WriteString(fmt.Sprintf("%-11s", "HEAD:"))
+	b.WriteString(uiansi.Reset)
+	b.WriteString(hash)
+	b.WriteString(" ")
+	b.WriteString(uiansi.Grey)
+	b.WriteString(subject)
+	b.WriteString(uiansi.Reset)
+	b.WriteString("\n")
 }
 
 func renderSwitchLogTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) string {
@@ -210,22 +220,24 @@ func renderSwitchLogTab(commandCtx context.Context, repoCtx *gitx.RepoContext, b
 
 func renderSwitchLogTable(entries []switchLogEntry) string {
 	var b strings.Builder
-	b.WriteString(ansiGrey + "HASH     DIFF         AGE          MESSAGE" + ansiReset + "\n")
+	b.WriteString(uiansi.Grey + "HASH     DIFF         AGE          MESSAGE" + uiansi.Reset + "\n")
 	for _, entry := range entries {
 		hash := fmt.Sprintf("%-7s", entry.shortHash)
 		diff := fmt.Sprintf("+%d -%d", entry.added, entry.deleted)
-		b.WriteString(ansiGrey + hash + ansiReset)
+		b.WriteString(uiansi.Grey + hash + uiansi.Reset)
 		b.WriteString("  ")
-		b.WriteString(ansiGreen + "+" + strconv.Itoa(entry.added) + ansiReset)
+		b.WriteString(uiansi.Green + "+" + strconv.Itoa(entry.added) + uiansi.Reset)
 		b.WriteString(" ")
-		b.WriteString(ansiDiffRed + "-" + strconv.Itoa(entry.deleted) + ansiReset)
+		b.WriteString(uiansi.DiffRed + "-" + strconv.Itoa(entry.deleted) + uiansi.Reset)
 		if pad := 11 - len(diff); pad > 0 {
 			b.WriteString(strings.Repeat(" ", pad))
 		}
 		b.WriteString("  ")
-		b.WriteString(ansiGrey + fmt.Sprintf("%-12s", entry.age) + ansiReset)
+		b.WriteString(uiansi.Grey + fmt.Sprintf("%-12s", entry.age) + uiansi.Reset)
 		b.WriteString(" ")
+		b.WriteString(uiansi.Grey)
 		b.WriteString(entry.subject)
+		b.WriteString(uiansi.Reset)
 		b.WriteString("\n")
 	}
 	return b.String()
@@ -236,29 +248,27 @@ func renderSwitchDefaultDiffTab(commandCtx context.Context, repoCtx *gitx.RepoCo
 	if strings.TrimSpace(defaultBranch) == "" {
 		defaultBranch = "main"
 	}
-	return renderSwitchDiffTab(commandCtx, repoCtx, branch, defaultBranch, "default branch")
+	return renderSwitchDiffTab(commandCtx, repoCtx, branch, defaultBranch)
 }
 
 func renderSwitchUpstreamDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string) string {
 	upstream, err := branchUpstream(commandCtx, repoCtx, branch)
 	if err != nil {
-		return "Diff vs upstream\n----------------\nPreview unavailable: " + err.Error()
+		return renderSwitchDiffTabMessage("upstream", branch, "Preview unavailable: "+err.Error())
 	}
 	if strings.TrimSpace(upstream) == "" {
-		return "Diff vs upstream\n----------------\nBranch has no upstream tracking branch."
+		return renderSwitchDiffTabMessage("upstream", branch, "Branch has no upstream tracking branch.")
 	}
-	return renderSwitchDiffTab(commandCtx, repoCtx, branch, upstream, "upstream")
+	return renderSwitchDiffTab(commandCtx, repoCtx, branch, upstream)
 }
 
-func renderSwitchDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string, againstRef string, refLabel string) string {
+func renderSwitchDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, branch string, againstRef string) string {
 	var b strings.Builder
 	b.WriteString("\n")
-	b.WriteString("Branch: ")
-	b.WriteString(branch)
-	b.WriteString("\n")
-	b.WriteString("Compare: ")
 	b.WriteString(againstRef)
-	b.WriteString("...")
+	b.WriteString(uiansi.Grey)
+	b.WriteString(" vs. ")
+	b.WriteString(uiansi.Reset)
 	b.WriteString(branch)
 	b.WriteString("\n\n")
 
@@ -280,17 +290,24 @@ func renderSwitchDiffTab(commandCtx context.Context, repoCtx *gitx.RepoContext, 
 	}
 
 	if strings.TrimSpace(stdout) == "" {
-		b.WriteString("No diff between ")
-		b.WriteString(branch)
-		b.WriteString(" and ")
-		b.WriteString(refLabel)
-		b.WriteString(" (")
-		b.WriteString(againstRef)
-		b.WriteString(").\n")
+		b.WriteString("No differences.\n")
 		return strings.TrimRight(b.String(), "\n")
 	}
 
 	b.WriteString(colorizeDiffStat(stdout))
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderSwitchDiffTabMessage(againstLabel string, branch string, message string) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(againstLabel)
+	b.WriteString(uiansi.Grey)
+	b.WriteString(" vs. ")
+	b.WriteString(uiansi.Reset)
+	b.WriteString(branch)
+	b.WriteString("\n\n")
+	b.WriteString(message)
 	return strings.TrimRight(b.String(), "\n")
 }
 
@@ -324,10 +341,10 @@ func colorizeDiffStatLine(line string) string {
 
 	changed := rightFields[0]
 	graph := strings.Join(rightFields[1:], " ")
-	graphColored := strings.ReplaceAll(graph, "+", ansiGreen+"+"+ansiReset)
-	graphColored = strings.ReplaceAll(graphColored, "-", ansiDiffRed+"-"+ansiReset)
+	graphColored := strings.ReplaceAll(graph, "+", uiansi.Green+"+"+uiansi.Reset)
+	graphColored = strings.ReplaceAll(graphColored, "-", uiansi.DiffRed+"-"+uiansi.Reset)
 
-	return fmt.Sprintf("%s%-56s%s | %2s %s", ansiGrey, left, ansiReset, changed, graphColored)
+	return fmt.Sprintf("%s%-56s%s | %2s %s", uiansi.Grey, left, uiansi.Reset, changed, graphColored)
 }
 
 func colorizeSummaryLine(line string) string {
@@ -337,16 +354,16 @@ func colorizeSummaryLine(line string) string {
 		if strings.Contains(segment, "insertion") {
 			segment = strings.ReplaceAll(segment, "(", "")
 			segment = strings.ReplaceAll(segment, ")", "")
-			fields[i] = ansiGreen + segment + ansiReset
+			fields[i] = uiansi.Green + segment + uiansi.Reset
 			continue
 		}
 		if strings.Contains(segment, "deletion") {
 			segment = strings.ReplaceAll(segment, "(", "")
 			segment = strings.ReplaceAll(segment, ")", "")
-			fields[i] = ansiDiffRed + segment + ansiReset
+			fields[i] = uiansi.DiffRed + segment + uiansi.Reset
 			continue
 		}
-		fields[i] = ansiGrey + segment + ansiReset
+		fields[i] = uiansi.Grey + segment + uiansi.Reset
 	}
 	return strings.Join(fields, ", ")
 }

--- a/internal/tui/switch_preview_test.go
+++ b/internal/tui/switch_preview_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSwitchLogEntriesParsesNumstatTotals(t *testing.T) {
+	stdout := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\taaaa\t2 hours ago\tadd feature\n3\t1\ta.txt\n2\t0\tb.txt\n"
+	entries := parseSwitchLogEntries(stdout)
+	if len(entries) != 1 {
+		t.Fatalf("parseSwitchLogEntries len = %d, want 1", len(entries))
+	}
+	if entries[0].shortHash != "aaaa" {
+		t.Fatalf("shortHash = %q, want %q", entries[0].shortHash, "aaaa")
+	}
+	if entries[0].added != 5 || entries[0].deleted != 1 {
+		t.Fatalf("numstat totals = +%d -%d, want +5 -1", entries[0].added, entries[0].deleted)
+	}
+}
+
+func TestParseSwitchNumstatLineBinaryFile(t *testing.T) {
+	added, deleted, ok := parseSwitchNumstatLine("-\t-\timage.png")
+	if !ok {
+		t.Fatalf("parseSwitchNumstatLine should parse binary-file markers")
+	}
+	if added != 0 || deleted != 0 {
+		t.Fatalf("binary numstat should be zeroed, got +%d -%d", added, deleted)
+	}
+}
+
+func TestLooksLikeFullCommitHash(t *testing.T) {
+	if !looksLikeFullCommitHash("0123456789abcdef0123456789abcdef01234567") {
+		t.Fatalf("expected valid full hash")
+	}
+	if looksLikeFullCommitHash("not-a-hash") {
+		t.Fatalf("expected invalid hash to be rejected")
+	}
+}
+
+func TestRenderSwitchLogTabUsesDiffHeader(t *testing.T) {
+	text := renderSwitchLogTable([]switchLogEntry{{shortHash: "aaaa", added: 845, deleted: 11, age: "2h", subject: "test"}})
+	if !strings.Contains(text, "DIFF") {
+		t.Fatalf("expected DIFF header, got: %q", text)
+	}
+	if !strings.Contains(text, "+845") || !strings.Contains(text, "-11") {
+		t.Fatalf("expected +845 and -11 in table, got: %q", text)
+	}
+}
+
+func TestColorizeDiffStatLineKeepsAlignment(t *testing.T) {
+	line := "README.md              |  2 +-"
+	out := colorizeDiffStatLine(line)
+	if !strings.Contains(out, "|  2") {
+		t.Fatalf("expected aligned count column, got: %q", out)
+	}
+	if !strings.Contains(out, "\x1b[38;5;114m+\x1b[0m") {
+		t.Fatalf("expected plus sign coloring, got: %q", out)
+	}
+	if !strings.Contains(out, "\x1b[38;5;203m-\x1b[0m") {
+		t.Fatalf("expected minus sign coloring, got: %q", out)
+	}
+}

--- a/internal/tui/switch_preview_test.go
+++ b/internal/tui/switch_preview_test.go
@@ -61,3 +61,22 @@ func TestColorizeDiffStatLineKeepsAlignment(t *testing.T) {
 		t.Fatalf("expected minus sign coloring, got: %q", out)
 	}
 }
+
+func TestCompactRelativeAge(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "5 minutes ago", want: "5 min ago"},
+		{in: "about an hour ago", want: "1 hr ago"},
+		{in: "2 hours ago", want: "2 hr ago"},
+		{in: "1 second ago", want: "1 sec ago"},
+		{in: "3 days ago", want: "3 day ago"},
+	}
+
+	for _, tc := range tests {
+		if got := compactRelativeAge(tc.in); got != tc.want {
+			t.Fatalf("compactRelativeAge(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/uiansi/colors.go
+++ b/internal/uiansi/colors.go
@@ -1,0 +1,17 @@
+package uiansi
+
+const (
+	Reset = "\x1b[0m"
+
+	Grey       = "\x1b[38;5;244m"
+	Green      = "\x1b[38;5;114m"
+	Yellow     = "\x1b[38;5;228m"
+	Periwinkle = "\x1b[38;5;111m"
+	DiffRed    = "\x1b[38;5;203m"
+
+	TabActiveBg = "\x1b[48;2;26;46;44m"
+	TabActiveFg = "\x1b[38;2;244;237;224m"
+
+	InfoPurple    = "\x1b[38;2;135;136;176m"
+	InfoPurpleHex = "#8788b0"
+)

--- a/markdown/settings.md
+++ b/markdown/settings.md
@@ -1,0 +1,9 @@
+# Settings Ideas
+
+- Preview cache mode
+  - `prefetch` (current default): build all switch preview tabs for all rows upfront.
+  - `hybrid`: eager-build tabs 1-2, lazy-build tabs 3-4 on first open.
+  - `lazy`: build each tab only when opened.
+- UI theme customization
+  - color palette for picker, highlight, and preview accents.
+  - icon set for pointer/marker/current/default-branch indicators.

--- a/references/switch-preview-checklist.md
+++ b/references/switch-preview-checklist.md
@@ -1,0 +1,58 @@
+# Switch Preview Tabs Checklist
+
+This checklist tracks implementation of a stacked switch-picker preview with tabbed content.
+
+## Scope
+
+- Keep the existing `ft switch` fzf list as the primary picker.
+- Add a stacked preview pane under the list.
+- Add tab switching with `tab` / `shift-tab`.
+- Include tabs for:
+  1. HEAD+/- status
+  2. Commit log (hash, +/-, age, message)
+  3. Diff vs default branch
+  4. Diff vs upstream tracking branch
+- Skip AI summary for now.
+
+## Cache Strategy (V1)
+
+- Use an ephemeral per-session cache directory (`os.MkdirTemp`) created before launching fzf.
+- Prefetch all tab payloads for all picker rows in parallel with bounded worker concurrency.
+- Store each row/tab payload as a text file and pass hidden file paths in fzf payload fields.
+- Render preview content by reading cached files from a hidden CLI command.
+- Remove the cache directory when picker exits.
+
+### Why this for V1
+
+- Keeps fzf responsive while navigating rows/tabs.
+- Avoids shelling out to heavy git commands on every cursor move.
+- Avoids stale long-lived cache invalidation complexity.
+- Easy to evolve into lazy fill later if startup cost is too high.
+
+### Lazy cache location (future option)
+
+- If we move to persisted lazy cache, use:
+  - `$XDG_CACHE_HOME/ft/switch-preview/<repo-key>/...` when `XDG_CACHE_HOME` is set.
+  - Fallback: `~/.cache/ft/switch-preview/<repo-key>/...`.
+- `repo-key` should be a stable hash of `GitCommonDir`.
+
+## Implementation Checklist
+
+- [x] Add preview cache builder in `internal/tui` for switch rows/tabs.
+- [x] Add commit-log parser/renderer for `+/-` totals per commit.
+- [x] Add diff renderers for default branch and upstream branch tabs.
+- [x] Add fzf preview configuration (`--preview-window=down,...`) and `tab` / `shift-tab` bindings.
+- [x] Add hidden payload fields for tab file paths.
+- [x] Update selected-branch parser to ignore extra hidden fields.
+- [x] Add hidden CLI command to print cached preview files.
+- [x] Add tests for branch parsing with extended payload.
+- [x] Validate with `go test ./...`.
+- [x] Update docs/help text after validating UX.
+
+## Rollout Notes
+
+- Start with `ft switch` only.
+- Keep create/remove pickers unchanged.
+- If startup latency is noticeable on large repos, next step is hybrid strategy:
+  - eager tabs 1-2
+  - lazy tabs 3-4 with on-demand file generation.


### PR DESCRIPTION
Adds a preview window to the `ft switch` command, allowing the user to switch between different views: overview, commit log, vs. default, and vs. upstream