### PR TITLE
perf(create): batch branch metadata for -a

### DIFF
--- a/internal/gitx/branches.go
+++ b/internal/gitx/branches.go
@@ -2,6 +2,8 @@ package gitx
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -20,4 +22,105 @@ func ListLocalBranches(commandCtx context.Context, ctx *RepoContext) ([]string, 
 		out = append(out, line)
 	}
 	return out, nil
+}
+
+type LocalBranchSnapshot struct {
+	Branch   string
+	Commit   CommitInfo
+	Relation string
+}
+
+func ListLocalBranchSnapshots(commandCtx context.Context, ctx *RepoContext) ([]LocalBranchSnapshot, error) {
+	snapshots, err := listLocalBranchSnapshotsBatch(commandCtx, ctx)
+	if err == nil {
+		return snapshots, nil
+	}
+	return listLocalBranchSnapshotsFallback(commandCtx, ctx)
+}
+
+func listLocalBranchSnapshotsBatch(commandCtx context.Context, ctx *RepoContext) ([]LocalBranchSnapshot, error) {
+	format := fmt.Sprintf("%%(refname:short)%%x09%%(objectname:short=4)%%x09%%(ahead-behind:%s)%%x09%%(subject)", ctx.DefaultBranch)
+	stdout, stderr, exitCode, runErr := RunGitCommon(commandCtx, ctx, "for-each-ref", "--format="+format, "refs/heads")
+	if err := CommandError("list local branch snapshots", stderr, exitCode, runErr, "git for-each-ref failed"); err != nil {
+		return nil, err
+	}
+
+	snapshots := make([]LocalBranchSnapshot, 0)
+	parseFailures := 0
+	for _, rawLine := range strings.Split(stdout, "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) != 4 {
+			parseFailures++
+			continue
+		}
+
+		branch := strings.TrimSpace(parts[0])
+		if branch == "" {
+			parseFailures++
+			continue
+		}
+
+		hash := strings.TrimSpace(parts[1])
+		subject := strings.TrimSpace(parts[3])
+		commit := CommitInfo{}
+		if hash != "" && subject != "" {
+			commit = CommitInfo{Hash: hash, Subject: subject}
+		}
+
+		relation := relationFromAheadBehind(branch, ctx.DefaultBranch, strings.TrimSpace(parts[2]))
+		snapshots = append(snapshots, LocalBranchSnapshot{
+			Branch:   branch,
+			Commit:   commit,
+			Relation: relation,
+		})
+	}
+	if parseFailures > 0 {
+		return nil, fmt.Errorf("parse local branch snapshots")
+	}
+	return snapshots, nil
+}
+
+func relationFromAheadBehind(branch string, defaultBranch string, aheadBehind string) string {
+	if branch == defaultBranch {
+		return "-"
+	}
+
+	parts := strings.Fields(aheadBehind)
+	if len(parts) != 2 {
+		return "?"
+	}
+
+	ahead, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "?"
+	}
+	behind, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "?"
+	}
+	return fmt.Sprintf("A: %d B: %d", ahead, behind)
+}
+
+func listLocalBranchSnapshotsFallback(commandCtx context.Context, ctx *RepoContext) ([]LocalBranchSnapshot, error) {
+	branches, err := ListLocalBranches(commandCtx, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commits := FetchCommitsParallel(commandCtx, ctx, branches)
+	relations := FetchBranchRelationsParallel(commandCtx, ctx, branches)
+
+	snapshots := make([]LocalBranchSnapshot, 0, len(branches))
+	for i, branch := range branches {
+		snapshots = append(snapshots, LocalBranchSnapshot{
+			Branch:   branch,
+			Commit:   commits[i],
+			Relation: relations[i],
+		})
+	}
+	return snapshots, nil
 }

--- a/internal/gitx/branches_test.go
+++ b/internal/gitx/branches_test.go
@@ -1,0 +1,76 @@
+package gitx
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gbo-dev/feature-tree/internal/testutil"
+)
+
+func TestListLocalBranchSnapshotsIncludesCommitAndRelation(t *testing.T) {
+	repoCtx, _, featureWorktreePath := setupWorktreeTestRepo(t)
+
+	filePath := filepath.Join(featureWorktreePath, "snapshot-test.txt")
+	if err := os.WriteFile(filePath, []byte("snapshot\n"), 0o644); err != nil {
+		t.Fatalf("write snapshot file: %v", err)
+	}
+	testutil.RunGit(t, featureWorktreePath, "add", "snapshot-test.txt")
+	testutil.RunGit(t, featureWorktreePath, "commit", "-m", "snapshot branch commit")
+
+	snapshots, err := ListLocalBranchSnapshots(context.Background(), repoCtx)
+	if err != nil {
+		t.Fatalf("ListLocalBranchSnapshots returned error: %v", err)
+	}
+
+	byBranch := make(map[string]LocalBranchSnapshot, len(snapshots))
+	for _, snapshot := range snapshots {
+		byBranch[snapshot.Branch] = snapshot
+	}
+
+	mainSnapshot, ok := byBranch[repoCtx.DefaultBranch]
+	if !ok {
+		t.Fatalf("default branch %q missing from snapshots", repoCtx.DefaultBranch)
+	}
+	if mainSnapshot.Relation != "-" {
+		t.Fatalf("default branch relation = %q, want \"-\"", mainSnapshot.Relation)
+	}
+	if strings.TrimSpace(mainSnapshot.Commit.Hash) == "" || strings.TrimSpace(mainSnapshot.Commit.Subject) == "" {
+		t.Fatalf("default branch commit info should be populated, got %+v", mainSnapshot.Commit)
+	}
+
+	featureSnapshot, ok := byBranch["feature-worktree"]
+	if !ok {
+		t.Fatalf("feature-worktree missing from snapshots")
+	}
+	if !strings.Contains(featureSnapshot.Relation, "A:") || !strings.Contains(featureSnapshot.Relation, "B:") {
+		t.Fatalf("feature-worktree relation = %q, expected ahead/behind format", featureSnapshot.Relation)
+	}
+	if strings.TrimSpace(featureSnapshot.Commit.Hash) == "" || strings.TrimSpace(featureSnapshot.Commit.Subject) == "" {
+		t.Fatalf("feature-worktree commit info should be populated, got %+v", featureSnapshot.Commit)
+	}
+}
+
+func TestFetchBranchRelationsParallelReturnsUnknownForMissingBranch(t *testing.T) {
+	repoCtx, _, _ := setupWorktreeTestRepo(t)
+
+	relations := FetchBranchRelationsParallel(context.Background(), repoCtx, []string{
+		repoCtx.DefaultBranch,
+		"feature-worktree",
+		"missing-branch",
+	})
+	if len(relations) != 3 {
+		t.Fatalf("FetchBranchRelationsParallel len = %d, want 3", len(relations))
+	}
+	if relations[0] != "-" {
+		t.Fatalf("default branch relation = %q, want \"-\"", relations[0])
+	}
+	if !strings.Contains(relations[1], "A:") || !strings.Contains(relations[1], "B:") {
+		t.Fatalf("feature-worktree relation = %q, expected ahead/behind format", relations[1])
+	}
+	if relations[2] != "?" {
+		t.Fatalf("missing-branch relation = %q, want \"?\"", relations[2])
+	}
+}

--- a/internal/gitx/worktree.go
+++ b/internal/gitx/worktree.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 )
+
+const maxConcurrentBranchRelations = 8
 
 type Worktree struct {
 	Path         string
@@ -176,4 +179,36 @@ func BranchRelation(commandCtx context.Context, ctx *RepoContext, branch string)
 	}
 
 	return fmt.Sprintf("A: %d B: %d", ahead, behind), nil
+}
+
+func FetchBranchRelationsParallel(commandCtx context.Context, ctx *RepoContext, branches []string) []string {
+	results := make([]string, len(branches))
+	if len(branches) == 0 {
+		return results
+	}
+
+	limit := maxConcurrentBranchRelations
+	if len(branches) < limit {
+		limit = len(branches)
+	}
+
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for i, branch := range branches {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(idx int, branchName string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			relation, err := BranchRelation(commandCtx, ctx, branchName)
+			if err != nil || strings.TrimSpace(relation) == "" {
+				results[idx] = "?"
+				return
+			}
+			results[idx] = relation
+		}(i, branch)
+	}
+	wg.Wait()
+	return results
 }

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -335,29 +335,45 @@ func PickSwitchBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, currentBranch string, ctx *gitx.RepoContext, includeAllBranches bool) (string, error) {
 	branches := make([]string, 0, len(entries))
 	worktreeByBranch := make(map[string]gitx.Worktree, len(entries))
+	commitByBranch := make(map[string]gitx.CommitInfo, len(entries))
+	relationByBranch := make(map[string]string, len(entries))
 	for _, worktree := range entries {
 		branches = append(branches, worktree.Branch)
 		worktreeByBranch[worktree.Branch] = worktree
 	}
 
 	if includeAllBranches {
-		localBranches, err := gitx.ListLocalBranches(commandCtx, ctx)
+		snapshots, err := gitx.ListLocalBranchSnapshots(commandCtx, ctx)
 		if err != nil {
 			return "", err
 		}
-		for _, branch := range localBranches {
-			if _, ok := worktreeByBranch[branch]; ok {
+		for _, snapshot := range snapshots {
+			commitByBranch[snapshot.Branch] = snapshot.Commit
+			relationByBranch[snapshot.Branch] = snapshot.Relation
+			if _, ok := worktreeByBranch[snapshot.Branch]; ok {
 				continue
 			}
-			branches = append(branches, branch)
+			branches = append(branches, snapshot.Branch)
 		}
 	}
 
-	commits := gitx.FetchCommitsParallel(commandCtx, ctx, branches)
+	if len(commitByBranch) == 0 {
+		commits := gitx.FetchCommitsParallel(commandCtx, ctx, branches)
+		for i, branch := range branches {
+			commitByBranch[branch] = commits[i]
+		}
+	}
+	if len(relationByBranch) == 0 {
+		relations := gitx.FetchBranchRelationsParallel(commandCtx, ctx, branches)
+		for i, branch := range branches {
+			relationByBranch[branch] = relations[i]
+		}
+	}
+
 	fromPath := currentWorktreePath(entries, currentBranch)
 
 	rows := make([]pickerRow, 0, len(branches))
-	for i, branch := range branches {
+	for _, branch := range branches {
 		worktree, hasWorktree := worktreeByBranch[branch]
 		path := "(no worktree)"
 		state := "-"
@@ -369,8 +385,8 @@ func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 			}
 			state = gitx.DirtyState(dirty)
 		}
-		relation, err := gitx.BranchRelation(commandCtx, ctx, branch)
-		if err != nil {
+		relation := strings.TrimSpace(relationByBranch[branch])
+		if relation == "" {
 			relation = "?"
 		}
 		m := ""
@@ -379,7 +395,7 @@ func PickCreateBranch(commandCtx context.Context, entries []gitx.Worktree, curre
 		}
 		rows = append(rows, pickerRow{
 			branch:   branch,
-			commit:   commits[i],
+			commit:   commitByBranch[branch],
 			path:     path,
 			state:    state,
 			relation: relation,


### PR DESCRIPTION
Cut picker startup cost on large repos by fetching head+ahead/behind in one for-each-ref call instead of per-branch shellouts.

Fall back to legacy lookups when batch formatting is unavailable.