### PR TITLE
refactor: clean up and run deadcode and linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ Use `ft create <branch>` for any subsequent branches: it handles worktree creati
 | Command | Description |
 |---|---|
 | `ft clone <url> [dir]` | Clone a repo into bare-in-`.git` layout with an initial worktree |
-| `ft switch [branch]` | Switch to an existing worktree; opens fzf picker if no branch given (`tab`/`s-tab` preview tabs in picker) |
-| `ft create [branch]` | Create a branch worktree; picker opens only with `--all-branches` and no branch |
+| `ft switch [--create] [--base <branch>] [branch]` | Switch to an existing worktree; optionally create missing worktree; opens fzf picker if no branch given (`tab`/`s-tab` preview tabs in picker) |
+| `ft create [--all-branches] [--base <branch>] [branch]` | Create a branch worktree; picker opens only with `--all-branches` and no branch |
 | `ft list` | List worktrees with status |
 | `ft remove [branch]` | Remove a worktree (and optionally its branch) |
 | `ft squash [--base <branch>]` | Squash current branch commits into one |
-| `ft copy-include` | Sync include-manifest files across worktrees |
+| `ft pr <num> [--use-pr-ref]` | Fetch and checkout a PR as a worktree (`--use-pr-ref` forces `pull/<num>` naming) |
+| `ft copy-include [--from <branch>] [--to <branch>]` | Sync include-manifest files across worktrees |
 | `ft init [bash\|zsh]` | Print shell integration snippet |
 | `ft completion [bash\|zsh]` | Print tab-completion script |
 | `ft pr [num]` | Create worktree for specific PR num, similar to `gh pr checkout`|
@@ -172,7 +173,10 @@ Optional dead code analysis is available with `deadcode`:
 ```sh
 go install golang.org/x/tools/cmd/deadcode@latest
 deadcode ./...
+deadcode -test ./...
 ```
+
+Use `deadcode -test ./...` when you want test helpers counted as live; plain `deadcode ./...` reports only production-reachable code from main packages.
 
 <!-- ## TODO
 

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -30,10 +30,19 @@ func newCloneCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Cloned into %s\n", result.RepoRoot)
-			fmt.Fprintf(cmd.OutOrStdout(), "Default branch: %s\n", result.DefaultBranch)
-			fmt.Fprintf(cmd.OutOrStdout(), "Worktree: %s\n", result.WorktreePath)
-			fmt.Fprintf(cmd.OutOrStdout(), "\ncd %s/%s\n", result.RepoRoot, result.DefaultBranch)
+			out := cmd.OutOrStdout()
+			if _, err := fmt.Fprintf(out, "Cloned into %s\n", result.RepoRoot); err != nil {
+				return fmt.Errorf("ft: write clone output: %w", err)
+			}
+			if _, err := fmt.Fprintf(out, "Default branch: %s\n", result.DefaultBranch); err != nil {
+				return fmt.Errorf("ft: write clone output: %w", err)
+			}
+			if _, err := fmt.Fprintf(out, "Worktree: %s\n", result.WorktreePath); err != nil {
+				return fmt.Errorf("ft: write clone output: %w", err)
+			}
+			if _, err := fmt.Fprintf(out, "\ncd %s/%s\n", result.RepoRoot, result.DefaultBranch); err != nil {
+				return fmt.Errorf("ft: write clone output: %w", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -69,10 +69,15 @@ func newCreateCmd() *cobra.Command {
 				return err
 			}
 
+			out := cmd.OutOrStdout()
 			if result.Created {
-				fmt.Fprintf(cmd.OutOrStdout(), "Created worktree: %s -> %s\n", result.Branch, result.Path)
+				if _, err := fmt.Fprintf(out, "Created worktree: %s -> %s\n", result.Branch, result.Path); err != nil {
+					return fmt.Errorf("ft: write create output: %w", err)
+				}
 			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Already exists: %s (%s)\n", result.Branch, result.Path)
+				if _, err := fmt.Fprintf(out, "Already exists: %s (%s)\n", result.Branch, result.Path); err != nil {
+					return fmt.Errorf("ft: write create output: %w", err)
+				}
 			}
 
 			shell.EmitCDOrWarning(result.Path, cmd.OutOrStdout(), cmd.ErrOrStderr())

--- a/internal/cli/include.go
+++ b/internal/cli/include.go
@@ -54,7 +54,9 @@ func newIncludeCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Copied include entries from %s to %s\n", from, to)
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Copied include entries from %s to %s\n", from, to); err != nil {
+				return fmt.Errorf("ft: write copy-include output: %w", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -41,7 +41,9 @@ Source once in your shell config:
 				return err
 			}
 
-			fmt.Fprint(cmd.OutOrStdout(), script)
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), script); err != nil {
+				return fmt.Errorf("ft: write init script: %w", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/pickerpreview.go
+++ b/internal/cli/pickerpreview.go
@@ -40,7 +40,9 @@ func newPickerPreviewCmd() *cobra.Command {
 				return fmt.Errorf("ft: read preview cache file: %w", err)
 			}
 
-			fmt.Fprint(cmd.OutOrStdout(), string(data))
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), string(data)); err != nil {
+				return fmt.Errorf("ft: write preview cache output: %w", err)
+			}
 			return nil
 		},
 	}
@@ -124,7 +126,9 @@ func newPickerPreviewTabCmd() *cobra.Command {
 			}
 
 			header := renderPreviewHeaderLine(tab)
-			fmt.Fprint(cmd.OutOrStdout(), header+"\n"+string(data))
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), header+"\n"+string(data)); err != nil {
+				return fmt.Errorf("ft: write preview tab output: %w", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -58,13 +58,20 @@ Examples:
 				return err
 			}
 
+			out := cmd.OutOrStdout()
 			if result.Created {
-				fmt.Fprintf(cmd.OutOrStdout(), "Created worktree: %s -> %s\n", result.Branch, result.Path)
+				if _, err := fmt.Fprintf(out, "Created worktree: %s -> %s\n", result.Branch, result.Path); err != nil {
+					return fmt.Errorf("ft: write pr output: %w", err)
+				}
 			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Already exists: %s (%s)\n", result.Branch, result.Path)
+				if _, err := fmt.Fprintf(out, "Already exists: %s (%s)\n", result.Branch, result.Path); err != nil {
+					return fmt.Errorf("ft: write pr output: %w", err)
+				}
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Switched to %s (%s)\n", result.Branch, result.Path)
+			if _, err := fmt.Fprintf(out, "Switched to %s (%s)\n", result.Branch, result.Path); err != nil {
+				return fmt.Errorf("ft: write pr output: %w", err)
+			}
 			shell.EmitCDOrWarning(result.Path, cmd.OutOrStdout(), cmd.ErrOrStderr())
 
 			return nil

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -69,23 +69,47 @@ func newRemoveCmd() *cobra.Command {
 				return err
 			}
 
+			out := cmd.OutOrStdout()
+			writeLine := func(format string, args ...any) error {
+				if _, err := fmt.Fprintf(out, format, args...); err != nil {
+					return fmt.Errorf("ft: write remove output: %w", err)
+				}
+				return nil
+			}
+
 			if result.NoDeleteBranch {
-				fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", result.Path)
+				if err := writeLine("Removed worktree: %s\n", result.Path); err != nil {
+					return err
+				}
 			} else if result.DeletedMerged {
 				if result.TargetRef == svc.Ctx.DefaultBranch {
-					fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree and deleted merged branch: %s\n", result.Branch)
+					if err := writeLine("Removed worktree and deleted merged branch: %s\n", result.Branch); err != nil {
+						return err
+					}
 				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree and deleted branch: %s (fully contained in %s)\n", result.Branch, result.TargetRef)
+					if err := writeLine("Removed worktree and deleted branch: %s (fully contained in %s)\n", result.Branch, result.TargetRef); err != nil {
+						return err
+					}
 				}
 			} else if result.DeletedIdentical {
-				fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree and deleted branch: %s (identical to %s)\n", result.Branch, result.TargetRef)
+				if err := writeLine("Removed worktree and deleted branch: %s (identical to %s)\n", result.Branch, result.TargetRef); err != nil {
+					return err
+				}
 			} else if result.DeletedEquivalent {
-				fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree and deleted branch: %s (no effective changes vs %s)\n", result.Branch, result.TargetRef)
+				if err := writeLine("Removed worktree and deleted branch: %s (no effective changes vs %s)\n", result.Branch, result.TargetRef); err != nil {
+					return err
+				}
 			} else if result.DeletedForced {
-				fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree and force-deleted branch: %s\n", result.Branch)
+				if err := writeLine("Removed worktree and force-deleted branch: %s\n", result.Branch); err != nil {
+					return err
+				}
 			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", result.Path)
-				fmt.Fprintf(cmd.OutOrStdout(), "Kept branch: %s (not merged to %s; use -D to force delete)\n", result.Branch, result.TargetRef)
+				if err := writeLine("Removed worktree: %s\n", result.Path); err != nil {
+					return err
+				}
+				if err := writeLine("Kept branch: %s (not merged to %s; use -D to force delete)\n", result.Branch, result.TargetRef); err != nil {
+					return err
+				}
 			}
 
 			if strings.TrimSpace(result.FallbackPath) != "" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,8 +22,7 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			renderRootOverview(cmd)
-			return nil
+			return renderRootOverview(cmd)
 		},
 	}
 
@@ -90,12 +89,18 @@ var helpTemplate = fmt.Sprintf(`%s%sft%s (feature-tree) – lightweight git work
 	uiansi.InfoPurple, uiansi.Reset,
 )
 
-func renderRootOverview(cmd *cobra.Command) {
+func renderRootOverview(cmd *cobra.Command) error {
 	w := cmd.OutOrStdout()
 
-	fmt.Fprintf(w, "%s%sft%s (feature-tree) – lightweight git worktree helper\n\n", ansiBold, uiansi.InfoPurple, uiansi.Reset)
-	fmt.Fprintf(w, "%sUsage:%s\n", uiansi.InfoPurple, uiansi.Reset)
-	fmt.Fprintf(w, "  %sft%s <command> [flags]\n\n", uiansi.Periwinkle, uiansi.Reset)
+	if _, err := fmt.Fprintf(w, "%s%sft%s (feature-tree) – lightweight git worktree helper\n\n", ansiBold, uiansi.InfoPurple, uiansi.Reset); err != nil {
+		return fmt.Errorf("ft: write overview output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "%sUsage:%s\n", uiansi.InfoPurple, uiansi.Reset); err != nil {
+		return fmt.Errorf("ft: write overview output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "  %sft%s <command> [flags]\n\n", uiansi.Periwinkle, uiansi.Reset); err != nil {
+		return fmt.Errorf("ft: write overview output: %w", err)
+	}
 
 	visibleCommands := make([]*cobra.Command, 0, len(cmd.Commands()))
 	maxNameWidth := 0
@@ -109,10 +114,18 @@ func renderRootOverview(cmd *cobra.Command) {
 		}
 	}
 
-	fmt.Fprintf(w, "%sAvailable Commands:%s\n", uiansi.InfoPurple, uiansi.Reset)
+	if _, err := fmt.Fprintf(w, "%sAvailable Commands:%s\n", uiansi.InfoPurple, uiansi.Reset); err != nil {
+		return fmt.Errorf("ft: write overview output: %w", err)
+	}
 	for _, sub := range visibleCommands {
-		fmt.Fprintf(w, "  %s%-*s%s  %s\n", uiansi.Periwinkle, maxNameWidth, sub.Name(), uiansi.Reset, sub.Short)
+		if _, err := fmt.Fprintf(w, "  %s%-*s%s  %s\n", uiansi.Periwinkle, maxNameWidth, sub.Name(), uiansi.Reset, sub.Short); err != nil {
+			return fmt.Errorf("ft: write overview output: %w", err)
+		}
 	}
 
-	fmt.Fprintf(w, "\nRun %sft --help%s for full details.\n", uiansi.Periwinkle, uiansi.Reset)
+	if _, err := fmt.Fprintf(w, "\nRun %sft --help%s for full details.\n", uiansi.Periwinkle, uiansi.Reset); err != nil {
+		return fmt.Errorf("ft: write overview output: %w", err)
+	}
+
+	return nil
 }

--- a/internal/cli/squash.go
+++ b/internal/cli/squash.go
@@ -23,7 +23,7 @@ func newSquashCmd() *cobra.Command {
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			svc, err := core.NewService(cmd.Context())
 			if err != nil {
 				return err
@@ -96,7 +96,11 @@ func newSquashCmd() *cobra.Command {
 				return fmt.Errorf("ft: create temporary commit message file: %w", err)
 			}
 			tmpPath := tmpFile.Name()
-			defer os.Remove(tmpPath)
+			defer func() {
+				if removeErr := os.Remove(tmpPath); removeErr != nil && err == nil && !os.IsNotExist(removeErr) {
+					err = fmt.Errorf("ft: remove temporary commit message file: %w", removeErr)
+				}
+			}()
 
 			subject := fmt.Sprintf("squash: %s (%d commits)", current, count)
 			lines := []string{subject, "", "Squashed commits:"}
@@ -107,8 +111,13 @@ func newSquashCmd() *cobra.Command {
 				}
 				lines = append(lines, "- "+title)
 			}
-			_, _ = tmpFile.WriteString(strings.Join(lines, "\n") + "\n")
-			_ = tmpFile.Close()
+			if _, err = tmpFile.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+				_ = tmpFile.Close()
+				return fmt.Errorf("ft: write temporary commit message file: %w", err)
+			}
+			if err = tmpFile.Close(); err != nil {
+				return fmt.Errorf("ft: close temporary commit message file: %w", err)
+			}
 
 			_, stderr, exitCode, runErr = gitx.RunGit(cmd.Context(), "", "reset", "--soft", strings.TrimSpace(mergeBase))
 			if err := gitx.CommandError("reset branch for squash", stderr, exitCode, runErr, "git reset failed"); err != nil {
@@ -120,7 +129,9 @@ func newSquashCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Squashed %d commits on %s into one commit\n", count, current)
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Squashed %d commits on %s into one commit\n", count, current); err != nil {
+				return fmt.Errorf("ft: write squash output: %w", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -73,10 +73,15 @@ Interactive picker notes:
 				return err
 			}
 
+			out := cmd.OutOrStdout()
 			if result.Created {
-				fmt.Fprintf(cmd.OutOrStdout(), "Created worktree: %s -> %s\n", result.Branch, result.Path)
+				if _, err := fmt.Fprintf(out, "Created worktree: %s -> %s\n", result.Branch, result.Path); err != nil {
+					return fmt.Errorf("ft: write switch output: %w", err)
+				}
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Switched to %s (%s)\n", result.Branch, result.Path)
+			if _, err := fmt.Fprintf(out, "Switched to %s (%s)\n", result.Branch, result.Path); err != nil {
+				return fmt.Errorf("ft: write switch output: %w", err)
+			}
 			shell.EmitCDOrWarning(result.Path, cmd.OutOrStdout(), cmd.ErrOrStderr())
 
 			return nil

--- a/internal/core/include.go
+++ b/internal/core/include.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gbo-dev/feature-tree/internal/gitx"
 )
 
-func (s *Service) CopyIncludeBetweenBranches(fromBranch string, toBranch string) error {
+func (s *Service) CopyIncludeBetweenBranches(fromBranch string, toBranch string) (err error) {
 	worktrees, err := gitx.ListWorktrees(s.CommandCtx, s.Ctx)
 	if err != nil {
 		return err
@@ -41,7 +41,11 @@ func (s *Service) CopyIncludeBetweenBranches(fromBranch string, toBranch string)
 		}
 		return fmt.Errorf("ft: read include file %s: %w", includeManifestPath, err)
 	}
-	defer includeManifestFile.Close()
+	defer func() {
+		if closeErr := includeManifestFile.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("ft: close include file %s: %w", includeManifestPath, closeErr)
+		}
+	}()
 
 	scanner := bufio.NewScanner(includeManifestFile)
 	for scanner.Scan() {
@@ -140,12 +144,16 @@ func copyPreservingShape(src string, dst string) error {
 	return copyFile(src, dst)
 }
 
-func copyFile(src string, dst string) error {
+func copyFile(src string, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("ft: open include source file %s: %w", src, err)
 	}
-	defer in.Close()
+	defer func() {
+		if closeErr := in.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("ft: close include source file %s: %w", src, closeErr)
+		}
+	}()
 
 	info, err := in.Stat()
 	if err != nil {
@@ -160,13 +168,17 @@ func copyFile(src string, dst string) error {
 	if err != nil {
 		return fmt.Errorf("ft: open include destination file %s: %w", dst, err)
 	}
-	defer out.Close()
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("ft: close include destination file %s: %w", dst, closeErr)
+		}
+	}()
 
-	if _, err := io.Copy(out, in); err != nil {
+	if _, err = io.Copy(out, in); err != nil {
 		return fmt.Errorf("ft: copy %s -> %s: %w", src, dst, err)
 	}
 
-	if err := out.Sync(); err != nil {
+	if err = out.Sync(); err != nil {
 		return fmt.Errorf("ft: sync include destination file %s: %w", dst, err)
 	}
 

--- a/internal/core/pr.go
+++ b/internal/core/pr.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
@@ -16,10 +15,6 @@ type PRInfo struct {
 	BaseBranch string
 	BaseSHA    string
 	Title      string
-}
-
-func (s *Service) FetchAndCheckoutPR(prNumber int) (*PRResult, error) {
-	return s.FetchAndCheckoutPRWithOptions(prNumber, PRCheckoutOptions{})
 }
 
 type PRCheckoutOptions struct {
@@ -74,18 +69,13 @@ func (s *Service) FetchAndCheckoutPRWithOptions(prNumber int, options PRCheckout
 		Created: result.Created,
 	}, nil
 }
-
-func (s *Service) GetPRInfo(prNumber int) (*PRInfo, error) {
-	return s.getPRInfo(prNumber, false)
-}
-
 func (s *Service) getPRInfo(prNumber int, usePRRef bool) (*PRInfo, error) {
 	refsToTry := []string{
 		fmt.Sprintf("refs/pull/%d/head", prNumber),
 		fmt.Sprintf("refs/pull/%d/merge", prNumber),
 	}
 
-	headRef := fmt.Sprintf("pull/%d", prNumber)
+	var headRef string
 	var headSHA string
 
 	for _, ref := range refsToTry {
@@ -253,15 +243,4 @@ func (s *Service) findBranchNameBySHA(refNamespace string, headSHA string, strip
 	}
 
 	return ""
-}
-
-func ParsePRNumber(input string) (int, error) {
-	prNum, err := strconv.Atoi(input)
-	if err != nil {
-		return 0, fmt.Errorf("ft: %q is not a valid PR number", input)
-	}
-	if prNum <= 0 {
-		return 0, fmt.Errorf("ft: PR number must be positive")
-	}
-	return prNum, nil
 }

--- a/internal/core/pr_test.go
+++ b/internal/core/pr_test.go
@@ -12,45 +12,6 @@ import (
 	"github.com/gbo-dev/feature-tree/internal/testutil"
 )
 
-func TestParsePRNumber(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    int
-		wantErr bool
-	}{
-		{name: "valid positive", input: "123", want: 123, wantErr: false},
-		{name: "valid single digit", input: "1", want: 1, wantErr: false},
-		{name: "zero", input: "0", want: 0, wantErr: true},
-		{name: "negative", input: "-1", want: 0, wantErr: true},
-		{name: "non-numeric", input: "abc", want: 0, wantErr: true},
-		{name: "empty", input: "", want: 0, wantErr: true},
-		{name: "with spaces", input: " 123 ", want: 0, wantErr: true},
-		{name: "with leading zeros", input: "007", want: 7, wantErr: false},
-		{name: "large number", input: "2147483647", want: 2147483647, wantErr: false},
-		{name: "float-like", input: "1.5", want: 0, wantErr: true},
-		{name: "with letters", input: "123abc", want: 0, wantErr: true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParsePRNumber(tc.input)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("ParsePRNumber(%q) expected error, got nil", tc.input)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("ParsePRNumber(%q) unexpected error: %v", tc.input, err)
-				}
-				if got != tc.want {
-					t.Fatalf("ParsePRNumber(%q) = %d, want %d", tc.input, got, tc.want)
-				}
-			}
-		})
-	}
-}
-
 func TestGetPRInfoFetchesFromOrigin(t *testing.T) {
 	base := t.TempDir()
 	source := filepath.Join(base, "source")
@@ -91,18 +52,18 @@ func TestGetPRInfoFetchesFromOrigin(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	prInfo, err := svc.GetPRInfo(42)
+	prInfo, err := svc.getPRInfo(42, false)
 	if err != nil {
-		t.Fatalf("GetPRInfo returned error: %v", err)
+		t.Fatalf("getPRInfo returned error: %v", err)
 	}
 	if prInfo.Number != 42 {
-		t.Fatalf("GetPRInfo Number = %d, want 42", prInfo.Number)
+		t.Fatalf("getPRInfo Number = %d, want 42", prInfo.Number)
 	}
 	if prInfo.HeadRef != featureBranch {
-		t.Fatalf("GetPRInfo HeadRef = %q, want %q", prInfo.HeadRef, featureBranch)
+		t.Fatalf("getPRInfo HeadRef = %q, want %q", prInfo.HeadRef, featureBranch)
 	}
 	if prInfo.BaseBranch != cloneResult.DefaultBranch {
-		t.Fatalf("GetPRInfo BaseBranch = %q, want %q", prInfo.BaseBranch, cloneResult.DefaultBranch)
+		t.Fatalf("getPRInfo BaseBranch = %q, want %q", prInfo.BaseBranch, cloneResult.DefaultBranch)
 	}
 }
 
@@ -151,23 +112,23 @@ func TestFetchAndCheckoutPRCreatesWorktree(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	result, err := svc.FetchAndCheckoutPR(99)
+	result, err := svc.FetchAndCheckoutPRWithOptions(99, PRCheckoutOptions{})
 	if err != nil {
-		t.Fatalf("FetchAndCheckoutPR returned error: %v", err)
+		t.Fatalf("FetchAndCheckoutPRWithOptions returned error: %v", err)
 	}
 	if result.Number != 99 {
-		t.Fatalf("FetchAndCheckoutPR Number = %d, want 99", result.Number)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Number = %d, want 99", result.Number)
 	}
 	if result.Branch != featureBranch {
-		t.Fatalf("FetchAndCheckoutPR Branch = %q, want %q", result.Branch, featureBranch)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Branch = %q, want %q", result.Branch, featureBranch)
 	}
 	if !result.Created {
-		t.Fatalf("FetchAndCheckoutPR Created = false, want true")
+		t.Fatalf("FetchAndCheckoutPRWithOptions Created = false, want true")
 	}
 
 	expectedPath := filepath.Join(cloneResult.RepoRoot, featureBranch)
 	if result.Path != expectedPath {
-		t.Fatalf("FetchAndCheckoutPR Path = %q, want %q", result.Path, expectedPath)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Path = %q, want %q", result.Path, expectedPath)
 	}
 }
 
@@ -267,12 +228,12 @@ func TestFetchAndCheckoutPRSetsTrackingToRemoteHeadBranch(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	result, err := svc.FetchAndCheckoutPR(202)
+	result, err := svc.FetchAndCheckoutPRWithOptions(202, PRCheckoutOptions{})
 	if err != nil {
-		t.Fatalf("FetchAndCheckoutPR returned error: %v", err)
+		t.Fatalf("FetchAndCheckoutPRWithOptions returned error: %v", err)
 	}
 	if result.Branch != featureBranch {
-		t.Fatalf("FetchAndCheckoutPR Branch = %q, want %q", result.Branch, featureBranch)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Branch = %q, want %q", result.Branch, featureBranch)
 	}
 
 	trackRemote := testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "config", "--get", "branch."+featureBranch+".remote")
@@ -372,24 +333,24 @@ func TestFetchAndCheckoutPRReusesExistingWorktree(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	result, err := svc.FetchAndCheckoutPR(77)
+	result, err := svc.FetchAndCheckoutPRWithOptions(77, PRCheckoutOptions{})
 	if err != nil {
-		t.Fatalf("FetchAndCheckoutPR returned error: %v", err)
+		t.Fatalf("FetchAndCheckoutPRWithOptions returned error: %v", err)
 	}
 	if result.Number != 77 {
-		t.Fatalf("FetchAndCheckoutPR Number = %d, want 77", result.Number)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Number = %d, want 77", result.Number)
 	}
 	if result.Branch != "pull/77" {
-		t.Fatalf("FetchAndCheckoutPR Branch = %q, want %q", result.Branch, "pull/77")
+		t.Fatalf("FetchAndCheckoutPRWithOptions Branch = %q, want %q", result.Branch, "pull/77")
 	}
 	if result.Created {
-		t.Fatalf("FetchAndCheckoutPR Created = true, want false for existing worktree")
+		t.Fatalf("FetchAndCheckoutPRWithOptions Created = true, want false for existing worktree")
 	}
 
 	canonicalPath := testutil.CanonicalPath(t, result.Path)
 	canonicalWant := testutil.CanonicalPath(t, pullBranchPath)
 	if canonicalPath != canonicalWant {
-		t.Fatalf("FetchAndCheckoutPR Path = %q, want %q", canonicalPath, canonicalWant)
+		t.Fatalf("FetchAndCheckoutPRWithOptions Path = %q, want %q", canonicalPath, canonicalWant)
 	}
 }
 
@@ -417,9 +378,9 @@ func TestGetPRInfoHandlesNonexistentPR(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	_, err = svc.GetPRInfo(999999)
+	_, err = svc.getPRInfo(999999, false)
 	if err == nil {
-		t.Fatalf("GetPRInfo expected error for nonexistent PR, got nil")
+		t.Fatalf("getPRInfo expected error for nonexistent PR, got nil")
 	}
 }
 
@@ -463,9 +424,9 @@ func TestEnsureLocalRefUpdatedRefreshesStaleRef(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	prInfo, err := svc.GetPRInfo(55)
+	prInfo, err := svc.getPRInfo(55, false)
 	if err != nil {
-		t.Fatalf("GetPRInfo returned error: %v", err)
+		t.Fatalf("getPRInfo returned error: %v", err)
 	}
 
 	err = svc.ensureLocalRefUpdated(prInfo)
@@ -506,8 +467,8 @@ func TestFetchAndCheckoutPRNoOriginFails(t *testing.T) {
 		CommandCtx: context.Background(),
 	}
 
-	_, err = svc.FetchAndCheckoutPR(42)
+	_, err = svc.FetchAndCheckoutPRWithOptions(42, PRCheckoutOptions{})
 	if err == nil {
-		t.Fatalf("FetchAndCheckoutPR expected error without origin, got nil")
+		t.Fatalf("FetchAndCheckoutPRWithOptions expected error without origin, got nil")
 	}
 }

--- a/internal/gitx/exec.go
+++ b/internal/gitx/exec.go
@@ -24,11 +24,13 @@ func RunGit(ctx context.Context, dir string, args ...string) (stdout string, std
 }
 
 func RunGitCommon(commandCtx context.Context, repoCtx *RepoContext, args ...string) (stdout string, stderr string, exitCode int, err error) {
+	if repoCtx == nil {
+		return "", "", -1, fmt.Errorf("ft: missing repository context")
+	}
+
 	fullArgs := append([]string{"--git-dir", repoCtx.GitCommonDir}, args...)
 	workingDir := ""
-	if repoCtx != nil {
-		workingDir = strings.TrimSpace(repoCtx.RepoRoot)
-	}
+	workingDir = strings.TrimSpace(repoCtx.RepoRoot)
 	return runCommand(normalizeCommandContext(commandCtx), workingDir, "git", fullArgs...)
 }
 

--- a/internal/shell/integration.go
+++ b/internal/shell/integration.go
@@ -20,13 +20,19 @@ func EmitCDOrWarning(path string, stdout io.Writer, stderr io.Writer) {
 	}
 
 	if os.Getenv(EmitCDEnv) == EmitCDValue {
-		fmt.Fprintf(stdout, "%s%s\n", CDMarkerPrefix, path)
+		if _, err := fmt.Fprintf(stdout, "%s%s\n", CDMarkerPrefix, path); err != nil {
+			return
+		}
 		return
 	}
 
 	hint := PreferredShell()
-	fmt.Fprintln(stderr, "ft: shell integration not active, so automatic directory switching is unavailable")
-	fmt.Fprintf(stderr, "ft: run `eval \"$(ft init %s)\"` to enable auto-cd in this shell\n", hint)
+	if _, err := fmt.Fprintln(stderr, "ft: shell integration not active, so automatic directory switching is unavailable"); err != nil {
+		return
+	}
+	if _, err := fmt.Fprintf(stderr, "ft: run `eval \"$(ft init %s)\"` to enable auto-cd in this shell\n", hint); err != nil {
+		return
+	}
 }
 
 func InitScript(shellName string) (string, error) {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -176,7 +176,7 @@ func fitListLayout(l rowLayout) rowLayout {
 	overflow = reduceWidth(&l.commitWidth, colWidthCommit, overflow)
 	overflow = reduceWidth(&l.relationWidth, colWidthRelation, overflow)
 	overflow = reduceWidth(&l.branchWidth, branchColMinWidth, overflow)
-	overflow = reduceWidth(&l.stateWidth, colWidthState, overflow)
+	reduceWidth(&l.stateWidth, colWidthState, overflow)
 
 	return l
 }
@@ -715,14 +715,18 @@ func PrintWorktreeList(commandCtx context.Context, entries []gitx.Worktree, curr
 		{colTitleRelation, l.relationWidth},
 		{colTitleCommit, l.commitWidth},
 	})
-	fmt.Fprintln(w, header)
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return fmt.Errorf("print worktree list header: %w", err)
+	}
 
 	for _, line := range buildFZFLines(rows, l) {
 		// Strip the hidden "\t<branch>" suffix — only the display column is printed.
 		if idx := strings.Index(line, "\t"); idx >= 0 {
 			line = line[:idx]
 		}
-		fmt.Fprintln(w, line)
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("print worktree list row: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -163,7 +163,11 @@ func renderSwitchHeadTab(row pickerRow) string {
 
 func writeSwitchHeadField(b *strings.Builder, label string, value string, valueColor string) {
 	b.WriteString(uiansi.InfoPurple)
-	b.WriteString(fmt.Sprintf("%-11s", label+":"))
+	labelText := label + ":"
+	b.WriteString(labelText)
+	if pad := 11 - len(labelText); pad > 0 {
+		b.WriteString(strings.Repeat(" ", pad))
+	}
 	b.WriteString(uiansi.Reset)
 	if valueColor != "" {
 		b.WriteString(valueColor)
@@ -177,7 +181,8 @@ func writeSwitchHeadField(b *strings.Builder, label string, value string, valueC
 
 func writeSwitchHeadCommitField(b *strings.Builder, hash string, subject string) {
 	b.WriteString(uiansi.InfoPurple)
-	b.WriteString(fmt.Sprintf("%-11s", "HEAD:"))
+	b.WriteString("HEAD:")
+	b.WriteString(strings.Repeat(" ", 6))
 	b.WriteString(uiansi.Reset)
 	b.WriteString(hash)
 	b.WriteString(" ")


### PR DESCRIPTION
- Use deadcode and golangci-lint to detect issues and clean up

AI:
- Check command output writes so IO failures surface instead of being silently ignored across CLI, TUI, and shell helpers. -Guard common git execution against nil repo context to avoid panic risk and satisfy static analysis.
- Remove stale PR wrapper APIs and parse helper to reduce surface area, then align tests and README command docs with the current interface.