### PR TITLE
feat(switch-preview): highlight ahead commits in commit log tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS
+
+## Repo Snapshot
+- Language: Go.
+- CLI entrypoint: cmd/ft/main.go.
+- Main areas:
+  - internal/cli: command wiring and integration behavior.
+  - internal/core: core feature-tree logic.
+  - internal/gitx: git command wrappers and repo context.
+  - internal/tui: picker and preview rendering.
+
+## Working Norms
+- Keep changes small and readable; prefer straightforward, clean, idiomatic Go.
+
+## Justfile
+- Format: just fmt
+- Unit/integration tests: just test
+- Lint: just lint
+- Dead code: just deadcode
+- Full local gate: just check
+- Race checks (slower): just race
+
+## Deadcode Note
+- deadcode without test roots (example: deadcode ./...) can report test helpers as unreachable.
+- This repo uses deadcode -test ./... in just deadcode so test-only helpers are treated correctly.
+
+## Expected Pre-Completion Checks
+- Run just check before finishing code changes.
+- Run just race when touching concurrency-sensitive behavior.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Use `ft create <branch>` for any subsequent branches: it handles worktree creati
 | `ft copy-include [--from <branch>] [--to <branch>]` | Sync include-manifest files across worktrees |
 | `ft init [bash\|zsh]` | Print shell integration snippet |
 | `ft completion [bash\|zsh]` | Print tab-completion script |
-| `ft pr [num]` | Create worktree for specific PR num, similar to `gh pr checkout`|
 
 Run `ft help` for flag details.
 

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -196,6 +196,16 @@ func renderSwitchLogTab(commandCtx context.Context, repoCtx *gitx.RepoContext, b
 	var b strings.Builder
 	b.WriteString("\n")
 
+	defaultBranch := strings.TrimSpace(repoCtx.DefaultBranch)
+	aheadHashes := map[string]struct{}{}
+	aheadLoadWarning := ""
+	hashes, err := loadSwitchAheadCommitHashes(commandCtx, repoCtx, defaultBranch, branch)
+	if err != nil {
+		aheadLoadWarning = err.Error()
+	} else {
+		aheadHashes = hashes
+	}
+
 	stdout, stderr, exitCode, runErr := gitx.RunGitCommon(
 		commandCtx,
 		repoCtx,
@@ -219,19 +229,61 @@ func renderSwitchLogTab(commandCtx context.Context, repoCtx *gitx.RepoContext, b
 		b.WriteString("No commits found.\n")
 		return strings.TrimRight(b.String(), "\n")
 	}
+	if aheadLoadWarning != "" {
+		b.WriteString(uiansi.Grey)
+		b.WriteString("Ahead commit highlighting unavailable: ")
+		b.WriteString(aheadLoadWarning)
+		b.WriteString(uiansi.Reset)
+		b.WriteString("\n")
+	}
 
-	b.WriteString(renderSwitchLogTable(entries))
+	b.WriteString(renderSwitchLogTable(entries, aheadHashes))
 
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func renderSwitchLogTable(entries []switchLogEntry) string {
+func loadSwitchAheadCommitHashes(commandCtx context.Context, repoCtx *gitx.RepoContext, defaultBranch string, branch string) (map[string]struct{}, error) {
+	hashes := map[string]struct{}{}
+	if branch == "" || branch == defaultBranch {
+		return hashes, nil
+	}
+	if defaultBranch == "" {
+		return nil, fmt.Errorf("default branch is unknown")
+	}
+
+	stdout, stderr, exitCode, runErr := gitx.RunGitCommon(commandCtx, repoCtx, "rev-list", defaultBranch+".."+branch)
+	if err := gitx.CommandError(fmt.Sprintf("read ahead commits for %q", branch), stderr, exitCode, runErr, "git rev-list failed"); err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(stdout, "\n") {
+		hash := strings.TrimSpace(line)
+		if looksLikeFullCommitHash(hash) {
+			hashes[hash] = struct{}{}
+		}
+	}
+
+	return hashes, nil
+}
+
+func renderSwitchLogTable(entries []switchLogEntry, aheadHashes map[string]struct{}) string {
 	var b strings.Builder
 	b.WriteString(uiansi.Grey + "HASH     DIFF         AGE          MESSAGE" + uiansi.Reset + "\n")
 	for _, entry := range entries {
+		entryColor := uiansi.Grey
+		if _, ok := aheadHashes[entry.fullHash]; ok {
+			entryColor = ""
+		}
+
 		hash := fmt.Sprintf("%-7s", entry.shortHash)
 		diff := fmt.Sprintf("+%d -%d", entry.added, entry.deleted)
-		b.WriteString(uiansi.Grey + hash + uiansi.Reset)
+		if entryColor != "" {
+			b.WriteString(entryColor)
+		}
+		b.WriteString(hash)
+		if entryColor != "" {
+			b.WriteString(uiansi.Reset)
+		}
 		b.WriteString("  ")
 		b.WriteString(uiansi.Green + "+" + strconv.Itoa(entry.added) + uiansi.Reset)
 		b.WriteString(" ")
@@ -240,16 +292,24 @@ func renderSwitchLogTable(entries []switchLogEntry) string {
 			b.WriteString(strings.Repeat(" ", pad))
 		}
 		b.WriteString("  ")
-		b.WriteString(uiansi.Grey)
+		if entryColor != "" {
+			b.WriteString(entryColor)
+		}
 		b.WriteString(entry.age)
 		if pad := switchLogAgeWidth - textwidth.Width(entry.age); pad > 0 {
 			b.WriteString(strings.Repeat(" ", pad))
 		}
-		b.WriteString(uiansi.Reset)
+		if entryColor != "" {
+			b.WriteString(uiansi.Reset)
+		}
 		b.WriteString(" ")
-		b.WriteString(uiansi.Grey)
+		if entryColor != "" {
+			b.WriteString(entryColor)
+		}
 		b.WriteString(entry.subject)
-		b.WriteString(uiansi.Reset)
+		if entryColor != "" {
+			b.WriteString(uiansi.Reset)
+		}
 		b.WriteString("\n")
 	}
 	return b.String()

--- a/internal/tui/switch_preview_test.go
+++ b/internal/tui/switch_preview_test.go
@@ -1,9 +1,23 @@
 package tui
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/gbo-dev/feature-tree/internal/uiansi"
 )
+
+func TestLoadSwitchAheadCommitHashesErrorsWhenDefaultBranchUnknown(t *testing.T) {
+	_, err := loadSwitchAheadCommitHashes(context.Background(), nil, "", "feature")
+	if err == nil {
+		t.Fatalf("expected error when default branch is unknown")
+	}
+	if !strings.Contains(err.Error(), "default branch is unknown") {
+		t.Fatalf("error = %q, want message to mention unknown default branch", err.Error())
+	}
+}
 
 func TestParseSwitchLogEntriesParsesNumstatTotals(t *testing.T) {
 	stdout := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\taaaa\t2 hours ago\tadd feature\n3\t1\ta.txt\n2\t0\tb.txt\n"
@@ -39,12 +53,37 @@ func TestLooksLikeFullCommitHash(t *testing.T) {
 }
 
 func TestRenderSwitchLogTabUsesDiffHeader(t *testing.T) {
-	text := renderSwitchLogTable([]switchLogEntry{{shortHash: "aaaa", added: 845, deleted: 11, age: "2h", subject: "test"}})
+	text := renderSwitchLogTable([]switchLogEntry{{shortHash: "aaaa", added: 845, deleted: 11, age: "2h", subject: "test"}}, nil)
 	if !strings.Contains(text, "DIFF") {
 		t.Fatalf("expected DIFF header, got: %q", text)
 	}
 	if !strings.Contains(text, "+845") || !strings.Contains(text, "-11") {
 		t.Fatalf("expected +845 and -11 in table, got: %q", text)
+	}
+}
+
+func TestRenderSwitchLogTableHighlightsAheadCommits(t *testing.T) {
+	aheadHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	baseHash := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	paddedAhead := fmt.Sprintf("%-7s", "aaaa")
+	paddedBase := fmt.Sprintf("%-7s", "bbbb")
+
+	text := renderSwitchLogTable([]switchLogEntry{
+		{fullHash: aheadHash, shortHash: "aaaa", added: 5, deleted: 1, age: "2h", subject: "ahead commit"},
+		{fullHash: baseHash, shortHash: "bbbb", added: 1, deleted: 0, age: "1d", subject: "base commit"},
+	}, map[string]struct{}{aheadHash: {}})
+
+	if strings.Contains(text, uiansi.Grey+paddedAhead+uiansi.Reset) {
+		t.Fatalf("expected ahead hash to use regular text color, got: %q", text)
+	}
+	if strings.Contains(text, uiansi.Grey+"ahead commit"+uiansi.Reset) {
+		t.Fatalf("expected ahead subject to use regular text color, got: %q", text)
+	}
+	if !strings.Contains(text, uiansi.Grey+paddedBase+uiansi.Reset) {
+		t.Fatalf("expected base hash to remain grey, got: %q", text)
+	}
+	if !strings.Contains(text, uiansi.Grey+"base commit"+uiansi.Reset) {
+		t.Fatalf("expected base subject to remain grey, got: %q", text)
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -9,6 +9,18 @@ fmt:
 test:
 	go test ./...
 
+lint:
+	golangci-lint run ./...
+
+deadcode:
+	deadcode -test ./...
+
+check:
+	just fmt
+	just test
+	just lint
+	just deadcode
+
 race:
 	go test -race ./...
 


### PR DESCRIPTION
- Use regular picker-style text for commits ahead of default in switch preview commit log, while keeping non-ahead entries grey and preserving existing diff colors.
- Add AGENTS.md for working in this repo
- Add new justfile recipes