### PR TITLE
fix(pr): refresh stale refs before naming

### DIFF
--- a/internal/core/pr.go
+++ b/internal/core/pr.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
@@ -30,6 +31,13 @@ func (s *Service) FetchAndCheckoutPRWithOptions(prNumber int, options PRCheckout
 	if err := s.ensureLocalRefUpdated(prInfo); err != nil {
 		return nil, err
 	}
+
+	if options.UsePRRef {
+		prInfo.HeadRef = fmt.Sprintf("pull/%d", prNumber)
+	} else {
+		prInfo.HeadRef = s.resolvePRBranchName(prNumber, prInfo.HeadSHA)
+	}
+	prInfo.HeadRemote = s.findBranchNameBySHA("refs/remotes/origin", prInfo.HeadSHA, true)
 
 	worktrees, err := gitx.ListWorktrees(s.CommandCtx, s.Ctx)
 	if err != nil {
@@ -189,14 +197,27 @@ func (s *Service) ensureLocalRefUpdated(prInfo *PRInfo) error {
 		currentSHA = strings.TrimSpace(stdout)
 	}
 
-	if currentSHA != "" && currentSHA == prInfo.HeadSHA {
-		return nil
-	}
-
-	_, stderr, exitCode, runErr := gitx.RunGitCommon(s.CommandCtx, s.Ctx, "fetch", "origin", fmt.Sprintf("pull/%d/head", prInfo.Number))
+	_, stderr, exitCode, runErr := gitx.RunGitCommon(
+		s.CommandCtx,
+		s.Ctx,
+		"fetch",
+		"origin",
+		fmt.Sprintf("pull/%d/head:%s", prInfo.Number, ref),
+	)
 	if err := gitx.CommandError("update PR ref", stderr, exitCode, runErr, "git fetch failed"); err != nil {
+		if currentSHA != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "ft: warning: failed to update PR #%d from origin; using cached ref %s\n", prInfo.Number, ref)
+			prInfo.HeadSHA = currentSHA
+			return nil
+		}
 		return fmt.Errorf("ft: failed to update PR #%d: %w", prInfo.Number, err)
 	}
+
+	stdout, stderr, exitCode, runErr = gitx.RunGitCommon(s.CommandCtx, s.Ctx, "rev-parse", "--verify", ref)
+	if err := gitx.CommandError("resolve updated PR commit", stderr, exitCode, runErr, "git rev-parse failed"); err != nil {
+		return fmt.Errorf("ft: failed to resolve PR #%d commit: %w", prInfo.Number, err)
+	}
+	prInfo.HeadSHA = strings.TrimSpace(stdout)
 
 	return nil
 }

--- a/internal/core/pr_test.go
+++ b/internal/core/pr_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -438,6 +439,124 @@ func TestEnsureLocalRefUpdatedRefreshesStaleRef(t *testing.T) {
 	updatedSHA := strings.TrimSpace(stdout)
 	if updatedSHA != prInfo.HeadSHA {
 		t.Fatalf("ensureLocalRefUpdated: expected SHA %q, got %q", prInfo.HeadSHA, updatedSHA)
+	}
+}
+
+func TestFetchAndCheckoutPRRefreshesStaleLocalPRRefBeforeResolvingBranchName(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	featureBranch := "feature-pr-refresh"
+	testutil.RunGit(t, source, "checkout", "-b", featureBranch)
+
+	prFile := filepath.Join(source, "refresh-pr-file.txt")
+	if err := os.WriteFile(prFile, []byte("refresh PR content\n"), 0o644); err != nil {
+		t.Fatalf("write refresh PR file: %v", err)
+	}
+	testutil.RunGit(t, source, "add", "refresh-pr-file.txt")
+	testutil.RunGit(t, source, "commit", "-m", "refresh PR commit")
+	testutil.RunGit(t, source, "checkout", "main")
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	prNumber := 808
+	featureSHA := testutil.RunGit(t, source, "rev-parse", "--verify", featureBranch)
+	staleSHA := testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "rev-parse", "--verify", "refs/heads/"+cloneResult.DefaultBranch)
+
+	testutil.RunGit(t, "", "--git-dir", remote, "update-ref", fmt.Sprintf("refs/pull/%d/head", prNumber), featureSHA)
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", fmt.Sprintf("refs/pull/%d/head", prNumber), staleSHA)
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	result, err := svc.FetchAndCheckoutPRWithOptions(prNumber, PRCheckoutOptions{})
+	if err != nil {
+		t.Fatalf("FetchAndCheckoutPRWithOptions returned error: %v", err)
+	}
+	if result.Branch != featureBranch {
+		t.Fatalf("FetchAndCheckoutPRWithOptions Branch = %q, want %q", result.Branch, featureBranch)
+	}
+
+	refSHA := testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "rev-parse", "--verify", fmt.Sprintf("refs/pull/%d/head", prNumber))
+	if refSHA != featureSHA {
+		t.Fatalf("refs/pull/%d/head = %q, want %q", prNumber, refSHA, featureSHA)
+	}
+}
+
+func TestFetchAndCheckoutPRWithCachedRefAndNoOriginWarnsAndUsesCache(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	testutil.InitRepoWithMain(t, source)
+
+	remote := filepath.Join(base, "origin.git")
+	testutil.RunGit(t, "", "clone", "--bare", source, remote)
+
+	target := filepath.Join(base, "repo")
+	cloneResult, err := gitx.CloneRepo(context.Background(), remote, target)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "update-ref", "refs/pull/42/head", "refs/heads/"+cloneResult.DefaultBranch)
+	testutil.RunGit(t, "", "--git-dir", cloneResult.GitCommonDir, "remote", "remove", "origin")
+
+	svc := &Service{
+		Ctx: &gitx.RepoContext{
+			RepoRoot:      cloneResult.RepoRoot,
+			GitCommonDir:  cloneResult.GitCommonDir,
+			DefaultBranch: cloneResult.DefaultBranch,
+			IncludeFile:   ".worktreeinclude",
+		},
+		CommandCtx: context.Background(),
+	}
+
+	originalStderr := os.Stderr
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe failed: %v", pipeErr)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = originalStderr
+	}()
+
+	result, err := svc.FetchAndCheckoutPRWithOptions(42, PRCheckoutOptions{})
+	if err != nil {
+		t.Fatalf("FetchAndCheckoutPRWithOptions returned error: %v", err)
+	}
+	if result.Branch != "pull/42" {
+		t.Fatalf("FetchAndCheckoutPRWithOptions Branch = %q, want %q", result.Branch, "pull/42")
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write pipe failed: %v", err)
+	}
+	warningBytes, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("read warning output failed: %v", readErr)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read pipe failed: %v", err)
+	}
+
+	warningOutput := string(warningBytes)
+	if !strings.Contains(warningOutput, "failed to update PR #42 from origin; using cached ref refs/pull/42/head") {
+		t.Fatalf("warning output = %q, want cached-ref warning", warningOutput)
 	}
 }
 


### PR DESCRIPTION
Prevent pull/<n> fallback from stale local PR refs.\nRecompute branch naming after ref refresh, and warn when fetch\nupdate fails but cached ref is used.