### PR TITLE
fix(remove): avoid stale refs during deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Use `deadcode -test ./...` when you want test helpers counted as live; plain `de
 
 - Harden and verify the cancellation path end-to-end: Ctrl+C should cancel the Cobra command context and terminate in-flight git subprocesses immediately (not only via timeout), with integration coverage for long-running operations.
 - Fix Unicode visible-width truncation/alignment issues in TUI rendering: current truncation mixes byte-based slicing with terminal-column assumptions, which can misalign rows or truncate incorrectly for wide glyphs, combining marks, emoji, and other multi-codepoint grapheme clusters (including cases where ellipsis width appears inconsistent across terminals/fonts).
+-  inject an io.Writer/logger into Service instead of hardcoding os.Stderr
 -->
 
 ## Approach

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -64,6 +64,10 @@ func newRemoveCmd() *cobra.Command {
 				}
 			}
 
+			if fetchErr := gitx.FetchOrigin(cmd.Context(), svc.Ctx); fetchErr != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "ft: could not fetch from origin (%s); using cached refs\n", fetchErr)
+			}
+
 			result, err := svc.RemoveWorktree(branch, forceWorktree, forceBranch, noDeleteBranch)
 			if err != nil {
 				return err

--- a/internal/gitx/exec.go
+++ b/internal/gitx/exec.go
@@ -90,6 +90,49 @@ func CommandError(action string, stderr string, exitCode int, err error, fallbac
 	return fmt.Errorf("ft: %s: %s", action, message)
 }
 
+const fetchTimeout = 30 * time.Second
+
+func FetchOrigin(commandCtx context.Context, ctx *RepoContext) error {
+	if ctx == nil {
+		return fmt.Errorf("fetch failed: missing repository context")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(normalizeCommandContext(commandCtx), fetchTimeout)
+	defer cancel()
+
+	fullArgs := append([]string{"--git-dir", ctx.GitCommonDir}, "fetch", "origin")
+	cmd := exec.CommandContext(fetchCtx, "git", fullArgs...)
+	if dir := strings.TrimSpace(ctx.RepoRoot); dir != "" {
+		cmd.Dir = dir
+	}
+
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	runErr := cmd.Run()
+	if runErr == nil {
+		return nil
+	}
+
+	if errors.Is(runErr, context.DeadlineExceeded) {
+		return fmt.Errorf("fetch failed: timed out after %s", fetchTimeout)
+	}
+	if errors.Is(runErr, context.Canceled) {
+		return nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		errText := strings.TrimSpace(errBuf.String())
+		if errText != "" {
+			return fmt.Errorf("fetch failed: %s", errText)
+		}
+		return fmt.Errorf("fetch failed: exit code %d", exitErr.ExitCode())
+	}
+
+	return fmt.Errorf("fetch failed: %w", runErr)
+}
+
 func ExpectSuccess(action string, stdout string, stderr string, exitCode int, err error, fallback string) (string, error) {
 	if cmdErr := CommandError(action, stderr, exitCode, err, fallback); cmdErr != nil {
 		return "", cmdErr

--- a/internal/gitx/exec_test.go
+++ b/internal/gitx/exec_test.go
@@ -77,3 +77,38 @@ func TestRunGitCommonWorksWhenProcessCWDWasDeleted(t *testing.T) {
 		t.Fatalf("RunGitCommon stdout = %q, want %q", stdout, "main")
 	}
 }
+
+func TestFetchOriginPrefixesErrors(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	testutil.InitRepoWithMain(t, repo)
+
+	repoCtx := &RepoContext{
+		RepoRoot:     repo,
+		GitCommonDir: filepath.Join(repo, ".git"),
+	}
+
+	err := FetchOrigin(context.Background(), repoCtx)
+	if err == nil {
+		t.Fatalf("FetchOrigin expected error when origin remote is missing")
+	}
+	if !strings.Contains(err.Error(), "fetch failed:") {
+		t.Fatalf("FetchOrigin error = %q, expected fetch failure context prefix", err.Error())
+	}
+}
+
+func TestFetchOriginTreatsCanceledContextAsNoOp(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	testutil.InitRepoWithMain(t, repo)
+
+	repoCtx := &RepoContext{
+		RepoRoot:     repo,
+		GitCommonDir: filepath.Join(repo, ".git"),
+	}
+
+	commandCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := FetchOrigin(commandCtx, repoCtx); err != nil {
+		t.Fatalf("FetchOrigin on canceled context = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
- fetch origin before remove to refresh refs
- detect timeout/cancel from cmd.Run error path
- prefix fetch failures so warnings are explicit
- add FetchOrigin regression tests for error context