### PR TITLE
feat(list): call out branch/path mismatch in worktrees

### DIFF
--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -307,6 +307,31 @@ func TestListOutsideGitRepoFails(t *testing.T) {
 	assertNoOutputOnError(t, stdout, stderr)
 }
 
+func TestListShowsBranchPathMismatchMarker(t *testing.T) {
+	repoRoot, mainWorktreePath := setupCLIRepo(t)
+
+	if _, _, err := runRootCommand(t, mainWorktreePath, "create", "feature-a"); err != nil {
+		t.Fatalf("ft create feature-a returned error: %v", err)
+	}
+
+	featurePath := filepath.Join(repoRoot, "feature-a")
+	testutil.RunGit(t, featurePath, "checkout", "-b", "other-branch")
+
+	stdout, stderr, err := runRootCommand(t, mainWorktreePath, "list")
+	if err != nil {
+		t.Fatalf("ft list returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("ft list stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "~") {
+		t.Fatalf("ft list output missing branch/path mismatch marker, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "other-branch") {
+		t.Fatalf("ft list output missing checked-out branch, got: %q", stdout)
+	}
+}
+
 func TestListAtDetachedHeadFailsWithClearMessage(t *testing.T) {
 	_, mainWorktreePath := setupCLIRepo(t)
 	testutil.RunGit(t, mainWorktreePath, "checkout", "--detach")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -61,7 +61,7 @@ var helpTemplate = fmt.Sprintf(`%s%sft%s (feature-tree) – lightweight git work
 %sNotes:%s
   - clone sets up bare-in-.git layout, resolves origin/HEAD, and creates the first worktree.
   - Uses include manifest from default branch worktree (default: .worktreeinclude).
-  - list markers: @ is current branch worktree, ^ is default branch worktree.
+  - list markers: @ is current branch worktree, ^ is default branch worktree, ~ is branch/path mismatch.
   - STATE shows clean or symbols: + staged, ! unstaged, ? untracked; combinations (e.g. +!?) mean multiple states.
   - switch without branch opens fzf picker when running in a TTY (preview tabs: tab/s-tab).
   - create without branch requires an explicit name unless --all-branches is used.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/gbo-dev/feature-tree/internal/gitx"
@@ -83,6 +84,18 @@ func SanitizeBranchName(branch string) string {
 	branch = strings.ReplaceAll(branch, "/", "-")
 	branch = strings.ReplaceAll(branch, "\\", "-")
 	return branch
+}
+
+// WorktreeBranchPathMismatch reports when an ft-layout worktree directory no
+// longer matches its checked-out branch (direct child of repoRoot only).
+func WorktreeBranchPathMismatch(repoRoot string, wt gitx.Worktree) bool {
+	if repoRoot == "" || wt.Path == "" || wt.Branch == "" {
+		return false
+	}
+	if filepath.Dir(wt.Path) != repoRoot {
+		return false
+	}
+	return SanitizeBranchName(wt.Branch) != filepath.Base(wt.Path)
 }
 
 func FindWorktreePath(worktrees []gitx.Worktree, branch string) string {

--- a/internal/core/worktree_match_test.go
+++ b/internal/core/worktree_match_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+)
+
+func TestWorktreeBranchPathMismatch(t *testing.T) {
+	repoRoot := "/repo"
+
+	tests := []struct {
+		name string
+		wt   gitx.Worktree
+		want bool
+	}{
+		{
+			name: "aligned main worktree",
+			wt:   gitx.Worktree{Path: "/repo/main", Branch: "main"},
+			want: false,
+		},
+		{
+			name: "aligned sanitized branch name",
+			wt:   gitx.Worktree{Path: "/repo/feature-a", Branch: "feature/a"},
+			want: false,
+		},
+		{
+			name: "checked out branch differs from dedicated directory",
+			wt:   gitx.Worktree{Path: "/repo/feature-a", Branch: "other-branch"},
+			want: true,
+		},
+		{
+			name: "ignore worktree outside repo root layout",
+			wt:   gitx.Worktree{Path: "/elsewhere/custom", Branch: "other-branch"},
+			want: false,
+		},
+		{
+			name: "ignore nested path under repo root",
+			wt:   gitx.Worktree{Path: "/repo/nested/feature-a", Branch: "other-branch"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WorktreeBranchPathMismatch(repoRoot, tc.wt)
+			if got != tc.want {
+				t.Fatalf("WorktreeBranchPathMismatch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	fzf "github.com/junegunn/fzf/src"
 
+	"github.com/gbo-dev/feature-tree/internal/core"
 	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/textwidth"
 	"github.com/gbo-dev/feature-tree/internal/uiansi"
@@ -68,14 +70,16 @@ func truncateCell(s string, max int) string {
 }
 
 type pickerRow struct {
-	branch   string
-	commit   gitx.CommitInfo
-	path     string
-	state    string
-	relation string
-	current  bool
-	marker   string
-	hidden   []string
+	branch         string
+	commit         gitx.CommitInfo
+	path           string
+	state          string
+	relation       string
+	current        bool
+	marker         string
+	branchMismatch bool
+	dedicatedDir   string
+	hidden         []string
 }
 
 func buildWorktreePickerRow(commandCtx context.Context, worktree gitx.Worktree, commit gitx.CommitInfo, currentBranch string, ctx *gitx.RepoContext, fromPath string) pickerRow {
@@ -91,14 +95,21 @@ func buildWorktreePickerRow(commandCtx context.Context, worktree gitx.Worktree, 
 	if worktree.Branch == ctx.DefaultBranch && worktree.Branch != currentBranch {
 		m = "^"
 	}
+	branchMismatch := core.WorktreeBranchPathMismatch(ctx.RepoRoot, worktree)
+	dedicatedDir := ""
+	if branchMismatch {
+		dedicatedDir = filepath.Base(worktree.Path)
+	}
 	return pickerRow{
-		branch:   worktree.Branch,
-		commit:   commit,
-		path:     gitx.RelativePath(worktree.Path, fromPath),
-		state:    gitx.DirtyState(dirty),
-		relation: relation,
-		current:  worktree.Branch == currentBranch,
-		marker:   m,
+		branch:         worktree.Branch,
+		commit:         commit,
+		path:           gitx.RelativePath(worktree.Path, fromPath),
+		state:          gitx.DirtyState(dirty),
+		relation:       relation,
+		current:        worktree.Branch == currentBranch,
+		marker:         m,
+		branchMismatch: branchMismatch,
+		dedicatedDir:   dedicatedDir,
 	}
 }
 
@@ -572,20 +583,30 @@ func runFZF(lines []string, prompt string, extraArgs ...string) (string, error) 
 	}
 }
 
+// buildRowPrefix renders list/picker row markers: @ current, ^ default branch, ~ branch/path mismatch.
+func buildRowPrefix(row pickerRow) string {
+	var markers strings.Builder
+	switch {
+	case row.current:
+		markers.WriteString(uiansi.Green + "@" + uiansi.Reset)
+	case row.marker == "^":
+		markers.WriteString(uiansi.Periwinkle + "^" + uiansi.Reset)
+	}
+	if row.branchMismatch {
+		markers.WriteString(uiansi.Yellow + "~" + uiansi.Reset)
+	}
+	if markers.Len() == 0 {
+		return "  "
+	}
+	return markers.String() + " "
+}
+
 // buildFZFLines emits "display\tbranch[\thidden...]". The hidden payload fields
 // after the first tab are for preview and parseSelectedBranch ignores them.
 func buildFZFLines(rows []pickerRow, l rowLayout) []string {
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
-		var prefix string
-		switch {
-		case row.current:
-			prefix = uiansi.Green + "@ " + uiansi.Reset
-		case row.marker == "^":
-			prefix = uiansi.Periwinkle + "^ " + uiansi.Reset
-		default:
-			prefix = "  "
-		}
+		prefix := buildRowPrefix(row)
 
 		b := truncateBranch(row.branch, l.branchWidth)
 		branchField := b + strings.Repeat(" ", l.branchWidth-textwidth.Width(b)+2)

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -78,6 +78,49 @@ func TestBuildFZFLinesAppendsHiddenFields(t *testing.T) {
 	}
 }
 
+func TestBuildFZFLinesShowsBranchPathMismatchMarker(t *testing.T) {
+	rows := []pickerRow{
+		{
+			branch:         "other-branch",
+			path:           "../feature-a",
+			state:          "clean",
+			relation:       "A: 0 B: 0",
+			branchMismatch: true,
+		},
+	}
+
+	layout := computeLayout(rows)
+	lines := buildFZFLines(rows, layout)
+	if len(lines) != 1 {
+		t.Fatalf("buildFZFLines len = %d, want 1", len(lines))
+	}
+	if !strings.Contains(lines[0], "~") {
+		t.Fatalf("buildFZFLines output missing mismatch marker: %q", lines[0])
+	}
+}
+
+func TestBuildFZFLinesShowsCurrentAndMismatchMarkersTogether(t *testing.T) {
+	rows := []pickerRow{
+		{
+			branch:         "other-branch",
+			path:           ".",
+			state:          "clean",
+			relation:       "A: 0 B: 0",
+			current:        true,
+			branchMismatch: true,
+		},
+	}
+
+	layout := computeLayout(rows)
+	lines := buildFZFLines(rows, layout)
+	if len(lines) != 1 {
+		t.Fatalf("buildFZFLines len = %d, want 1", len(lines))
+	}
+	if !strings.Contains(lines[0], "@") || !strings.Contains(lines[0], "~") {
+		t.Fatalf("buildFZFLines output missing current and mismatch markers: %q", lines[0])
+	}
+}
+
 func TestFitListLayoutKeepsLineWithinLimit(t *testing.T) {
 	layout := rowLayout{
 		branchWidth:   120,

--- a/internal/tui/switch_preview.go
+++ b/internal/tui/switch_preview.go
@@ -165,6 +165,10 @@ func renderSwitchHeadTab(row pickerRow) string {
 		stateColor = uiansi.Yellow
 	}
 	writeSwitchHeadField(&b, "STATE", row.state, stateColor)
+	if row.branchMismatch {
+		writeSwitchHeadField(&b, "DEDICATED", row.dedicatedDir, uiansi.Yellow)
+		writeSwitchHeadField(&b, "CHECKED OUT", row.branch, uiansi.Yellow)
+	}
 	writeSwitchHeadField(&b, "VS. MAIN", row.relation, uiansi.Grey)
 	if strings.TrimSpace(row.commit.Hash) != "" && strings.TrimSpace(row.commit.Subject) != "" {
 		writeSwitchHeadCommitField(&b, row.commit.Hash, row.commit.Subject)

--- a/internal/tui/switch_preview_test.go
+++ b/internal/tui/switch_preview_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/gbo-dev/feature-tree/internal/uiansi"
 )
 
+func TestRenderSwitchHeadTabShowsBranchPathMismatch(t *testing.T) {
+	text := renderSwitchHeadTab(pickerRow{
+		branch:         "other-branch",
+		path:           "../feature-a",
+		state:          "clean",
+		relation:       "A: 0 B: 0",
+		branchMismatch: true,
+		dedicatedDir:   "feature-a",
+	})
+
+	if !strings.Contains(text, "DEDICATED:") || !strings.Contains(text, "feature-a") {
+		t.Fatalf("expected dedicated directory in preview, got: %q", text)
+	}
+	if !strings.Contains(text, "CHECKED OUT:") || !strings.Contains(text, "other-branch") {
+		t.Fatalf("expected checked-out branch in preview, got: %q", text)
+	}
+}
+
 func TestLoadSwitchAheadCommitHashesErrorsWhenDefaultBranchUnknown(t *testing.T) {
 	_, err := loadSwitchAheadCommitHashes(context.Background(), nil, "", "feature")
 	if err == nil {

--- a/skill/feature-tree-skill/SKILL.md
+++ b/skill/feature-tree-skill/SKILL.md
@@ -42,6 +42,7 @@ repo/
 - Markers:
   - `@` = current branch worktree
   - `^` = default branch worktree
+  - `~` = worktree directory does not match checked-out branch (e.g. after manual `git checkout` in that directory)
 - `STATE` values:
   - `clean` or `dirty` with symbols
   - `+` staged, `!` unstaged, `?` untracked (combined when multiple apply)


### PR DESCRIPTION
Fixes #24

## Problem

When a worktree lives in a directory dedicated to one branch (e.g. `feature-a/`) but the user checks out a different branch there, `ft list` and related views previously showed only the checked-out branch with no indication the directory no longer matches.

## Solution

- Added `WorktreeBranchPathMismatch` detection in `internal/core`
- Extended list/picker row rendering with a yellow `~` marker when path and branch diverge
- Switch preview HEAD tab shows dedicated directory vs checked-out branch when mismatched

## Testing

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`

## Risk / Rollback

Display-only change — none.

## Reviewer Notes

- Detection uses directory basename vs sanitized branch name; dedicated name shown is the directory (e.g. `feature-a`), not the original ref (e.g. `feature/a`).
- Detached-HEAD worktrees remain excluded from `ListWorktrees` (pre-existing).
- `FindWorktreePath` still keys off checked-out branch; path-based lookup is a possible follow-up.

---
Opened manually after the issue → PR pipeline pushed branch `issue-24-agent` but could not create the PR (GitHub Actions PR creation was disabled at the time).

Made with [Cursor](https://cursor.com)