### PR TITLE
Tighten CLI/core boundaries and detached HEAD handling (#61)

### DIFF
--- a/internal/cli/branchcompletions.go
+++ b/internal/cli/branchcompletions.go
@@ -11,8 +11,14 @@ import (
 )
 
 func completionContext(cmd *cobra.Command) context.Context {
-	if cmd != nil && cmd.Context() != nil {
-		return cmd.Context()
+	if cmd == nil {
+		return context.Background()
+	}
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	if root := cmd.Root(); root != nil && root.Context() != nil {
+		return root.Context()
 	}
 	return context.Background()
 }

--- a/internal/cli/branchcompletions_context_test.go
+++ b/internal/cli/branchcompletions_context_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompletionContextUsesCommandContext(t *testing.T) {
+	type ctxKey struct{}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "from-cmd")
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	got := completionContext(cmd)
+	if got.Value(ctxKey{}) != "from-cmd" {
+		t.Fatalf("completionContext = %#v, want command context value %q", got, "from-cmd")
+	}
+}
+
+func TestCompletionContextFallsBackToRootContext(t *testing.T) {
+	type ctxKey struct{}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "from-root")
+	root := &cobra.Command{}
+	root.SetContext(ctx)
+
+	child := &cobra.Command{}
+	root.AddCommand(child)
+
+	got := completionContext(child)
+	if got.Value(ctxKey{}) != "from-root" {
+		t.Fatalf("completionContext = %#v, want root context value %q", got, "from-root")
+	}
+}
+
+func TestCompletionContextFallsBackToBackground(t *testing.T) {
+	cmd := &cobra.Command{}
+	got := completionContext(cmd)
+	if got == nil {
+		t.Fatalf("completionContext returned nil")
+	}
+	if got.Err() != nil {
+		t.Fatalf("background context should not be canceled: %v", got.Err())
+	}
+}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -9,7 +8,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/gbo-dev/feature-tree/internal/core"
-	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/shell"
 	"github.com/gbo-dev/feature-tree/internal/tui"
 )
@@ -44,22 +42,15 @@ func newCreateCmd() *cobra.Command {
 					return fmt.Errorf("branch name is required")
 				}
 
-				entries, err := gitx.ListWorktrees(cmd.Context(), svc.Ctx)
+				state, err := svc.WorktreeState(cmd.Context())
 				if err != nil {
-					return err
-				}
-				current, err := gitx.CurrentBranch(cmd.Context(), "")
-				if err != nil {
-					return fmt.Errorf("cannot infer branch from detached HEAD")
+					return mapDetachedHead(err, "cannot infer branch from detached HEAD")
 				}
 
 				if term.IsTerminal(int(os.Stdin.Fd())) {
-					picked, pickErr := tui.PickCreateBranch(cmd.Context(), entries, current, svc.Ctx, includeAllBranches)
+					picked, pickErr := tui.PickCreateBranch(cmd.Context(), state.Entries, state.CurrentBranch, svc.Ctx, includeAllBranches)
 					if pickErr != nil {
-						if errors.Is(pickErr, tui.ErrSelectionCancelled) {
-							return fmt.Errorf("selection cancelled")
-						}
-						return pickErr
+						return handlePickerError(pickErr)
 					}
 					branch = picked
 				} else {
@@ -75,11 +66,11 @@ func newCreateCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			if result.Created {
 				if _, err := fmt.Fprintf(out, "Created worktree: %s -> %s\n", result.Branch, result.Path); err != nil {
-					return fmt.Errorf("write create output: %w", err)
+					return errWriteOutput("create", err)
 				}
 			} else {
 				if _, err := fmt.Fprintf(out, "Already exists: %s (%s)\n", result.Branch, result.Path); err != nil {
-					return fmt.Errorf("write create output: %w", err)
+					return errWriteOutput("create", err)
 				}
 			}
 

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+	"github.com/gbo-dev/feature-tree/internal/tui"
+)
+
+func errWriteOutput(action string, err error) error {
+	return fmt.Errorf("write %s output: %w", action, err)
+}
+
+func errSelectionCancelled() error {
+	return fmt.Errorf("selection cancelled")
+}
+
+func mapDetachedHead(err error, userMsg string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, gitx.ErrDetachedHead) {
+		return fmt.Errorf("%s", userMsg)
+	}
+	return err
+}
+
+func mapCurrentBranchForList(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, gitx.ErrDetachedHead) {
+		return fmt.Errorf("cannot determine current branch while HEAD is detached; check out a branch and retry")
+	}
+	return fmt.Errorf("resolve current branch for list: %w", err)
+}
+
+func handlePickerError(err error) error {
+	if errors.Is(err, tui.ErrSelectionCancelled) {
+		return errSelectionCancelled()
+	}
+	return err
+}

--- a/internal/cli/include.go
+++ b/internal/cli/include.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gbo-dev/feature-tree/internal/core"
-	"github.com/gbo-dev/feature-tree/internal/gitx"
 )
 
 func newIncludeCmd() *cobra.Command {
@@ -40,9 +39,9 @@ func newIncludeCmd() *cobra.Command {
 
 			to := toBranch
 			if strings.TrimSpace(to) == "" {
-				to, err = gitx.CurrentBranch(cmd.Context(), "")
+				to, err = svc.CurrentBranch(cmd.Context())
 				if err != nil {
-					return fmt.Errorf("cannot infer destination branch from detached HEAD")
+					return mapDetachedHead(err, "cannot infer destination branch from detached HEAD")
 				}
 			}
 			to, err = svc.ResolveBranchShortcut(cmd.Context(), to)
@@ -55,7 +54,7 @@ func newIncludeCmd() *cobra.Command {
 			}
 
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Copied include entries from %s to %s\n", from, to); err != nil {
-				return fmt.Errorf("write copy-include output: %w", err)
+				return errWriteOutput("copy-include", err)
 			}
 			return nil
 		},

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"github.com/gbo-dev/feature-tree/internal/core"
-	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/tui"
 )
 
@@ -21,20 +17,12 @@ func newListCmd() *cobra.Command {
 				return err
 			}
 
-			entries, err := gitx.ListWorktrees(cmd.Context(), svc.Ctx)
+			state, err := svc.WorktreeState(cmd.Context())
 			if err != nil {
-				return err
+				return mapCurrentBranchForList(err)
 			}
 
-			current, currentErr := gitx.CurrentBranch(cmd.Context(), "")
-			if currentErr != nil {
-				if strings.Contains(strings.ToLower(currentErr.Error()), "detached") {
-					return fmt.Errorf("cannot determine current branch while HEAD is detached; check out a branch and retry")
-				}
-				return fmt.Errorf("resolve current branch for list: %w", currentErr)
-			}
-
-			return tui.PrintWorktreeList(cmd.Context(), entries, current, svc.Ctx, cmd.OutOrStdout())
+			return tui.PrintWorktreeList(cmd.Context(), state.Entries, state.CurrentBranch, svc.Ctx, cmd.OutOrStdout())
 		},
 	}
 }

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +10,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/gbo-dev/feature-tree/internal/core"
-	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/shell"
 	"github.com/gbo-dev/feature-tree/internal/tui"
 )
@@ -40,24 +38,21 @@ func newRemoveCmd() *cobra.Command {
 			if len(args) == 1 {
 				branch = args[0]
 			} else {
-				current, currentErr := gitx.CurrentBranch(cmd.Context(), "")
+				current, currentErr := svc.CurrentBranch(cmd.Context())
 				if currentErr != nil {
-					return fmt.Errorf("cannot infer branch from detached HEAD")
+					return mapDetachedHead(currentErr, "cannot infer branch from detached HEAD")
 				}
 
 				if current != svc.Ctx.DefaultBranch {
 					branch = current
 				} else if term.IsTerminal(int(os.Stdin.Fd())) {
-					entries, err := gitx.ListWorktrees(cmd.Context(), svc.Ctx)
+					state, err := svc.WorktreeState(cmd.Context())
 					if err != nil {
 						return err
 					}
-					picked, pickErr := tui.PickRemoveBranch(cmd.Context(), entries, current, svc.Ctx)
+					picked, pickErr := tui.PickRemoveBranch(cmd.Context(), state.Entries, current, svc.Ctx)
 					if pickErr != nil {
-						if errors.Is(pickErr, tui.ErrSelectionCancelled) {
-							return fmt.Errorf("selection cancelled")
-						}
-						return pickErr
+						return handlePickerError(pickErr)
 					}
 					branch = picked
 				} else {
@@ -65,13 +60,13 @@ func newRemoveCmd() *cobra.Command {
 				}
 			}
 
-			if fetchErr := gitx.FetchOrigin(cmd.Context(), svc.Ctx); fetchErr != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "could not fetch from origin (%s); using cached refs\n", fetchErr)
-			}
-
 			result, err := svc.RemoveWorktree(cmd.Context(), branch, forceWorktree, forceBranch, noDeleteBranch)
 			if err != nil {
 				return err
+			}
+
+			if strings.TrimSpace(result.FetchWarning) != "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "could not fetch from origin (%s); using cached refs\n", result.FetchWarning)
 			}
 
 			if err := renderRemoveResult(cmd.OutOrStdout(), result, svc.Ctx.DefaultBranch); err != nil {
@@ -97,7 +92,7 @@ func newRemoveCmd() *cobra.Command {
 func renderRemoveResult(w io.Writer, result *core.RemoveResult, defaultBranch string) error {
 	writeLine := func(format string, args ...any) error {
 		if _, err := fmt.Fprintf(w, format, args...); err != nil {
-			return fmt.Errorf("write remove output: %w", err)
+			return errWriteOutput("remove", err)
 		}
 		return nil
 	}

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -9,7 +8,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/gbo-dev/feature-tree/internal/core"
-	"github.com/gbo-dev/feature-tree/internal/gitx"
 	"github.com/gbo-dev/feature-tree/internal/shell"
 	"github.com/gbo-dev/feature-tree/internal/tui"
 )
@@ -48,22 +46,15 @@ Interactive picker notes:
 			if len(args) == 1 {
 				branch = args[0]
 			} else {
-				entries, err := gitx.ListWorktrees(cmd.Context(), svc.Ctx)
+				state, err := svc.WorktreeState(cmd.Context())
 				if err != nil {
-					return err
+					return mapDetachedHead(err, "cannot infer branch from detached HEAD")
 				}
 
-				current, err := gitx.CurrentBranch(cmd.Context(), "")
-				if err != nil {
-					return fmt.Errorf("cannot infer branch from detached HEAD")
-				}
 				if term.IsTerminal(int(os.Stdin.Fd())) {
-					picked, pickErr := tui.PickSwitchBranch(cmd.Context(), entries, current, svc.Ctx)
+					picked, pickErr := tui.PickSwitchBranch(cmd.Context(), state.Entries, state.CurrentBranch, svc.Ctx)
 					if pickErr != nil {
-						if errors.Is(pickErr, tui.ErrSelectionCancelled) {
-							return fmt.Errorf("selection cancelled")
-						}
-						return pickErr
+						return handlePickerError(pickErr)
 					}
 					branch = picked
 				} else {
@@ -79,11 +70,11 @@ Interactive picker notes:
 			out := cmd.OutOrStdout()
 			if result.Created {
 				if _, err := fmt.Fprintf(out, "Created worktree: %s -> %s\n", result.Branch, result.Path); err != nil {
-					return fmt.Errorf("write switch output: %w", err)
+					return errWriteOutput("switch", err)
 				}
 			}
 			if _, err := fmt.Fprintf(out, "Switched to %s (%s)\n", result.Branch, result.Path); err != nil {
-				return fmt.Errorf("write switch output: %w", err)
+				return errWriteOutput("switch", err)
 			}
 			shell.EmitCDOrWarning(result.Path, cmd.OutOrStdout(), cmd.ErrOrStderr())
 

--- a/internal/core/remove.go
+++ b/internal/core/remove.go
@@ -30,6 +30,11 @@ func (s *Service) RemoveWorktree(commandCtx context.Context, branch string, forc
 		return nil, fmt.Errorf("cannot use --force-branch with --no-delete-branch")
 	}
 
+	var fetchWarning string
+	if fetchErr := gitx.FetchOrigin(commandCtx, s.Ctx); fetchErr != nil {
+		fetchWarning = fetchErr.Error()
+	}
+
 	resolvedBranch, err := s.ResolveBranchShortcut(commandCtx, branch)
 	if err != nil {
 		return nil, err
@@ -62,6 +67,7 @@ func (s *Service) RemoveWorktree(commandCtx context.Context, branch string, forc
 	result := &RemoveResult{
 		Branch:         resolvedBranch,
 		Path:           target.Path,
+		FetchWarning:   fetchWarning,
 		NoDeleteBranch: noDeleteBranch,
 	}
 

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -45,6 +46,7 @@ type RemoveResult struct {
 	Path              string
 	FallbackPath      string
 	TargetRef         string
+	FetchWarning      string
 	DeletedMerged     bool
 	DeletedIdentical  bool
 	DeletedEquivalent bool
@@ -76,7 +78,10 @@ func (s *Service) ResolveBranchShortcut(commandCtx context.Context, input string
 	case "@":
 		current, err := gitx.CurrentBranch(commandCtx, "")
 		if err != nil {
-			return "", fmt.Errorf("HEAD is detached; @ is unavailable")
+			if errors.Is(err, gitx.ErrDetachedHead) {
+				return "", fmt.Errorf("HEAD is detached; @ is unavailable")
+			}
+			return "", fmt.Errorf("resolve current branch: %w", err)
 		}
 		return current, nil
 	default:

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -94,7 +95,7 @@ func TestResolveBranchShortcutDetachedHead(t *testing.T) {
 	if err == nil {
 		t.Fatalf("ResolveBranchShortcut(@) expected error on detached HEAD")
 	}
-	if !strings.Contains(err.Error(), "HEAD is detached") {
-		t.Fatalf("detached HEAD error = %q, expected mention of detached HEAD", err.Error())
+	if !errors.Is(err, gitx.ErrDetachedHead) && !strings.Contains(err.Error(), "HEAD is detached") {
+		t.Fatalf("detached HEAD error = %q, expected ErrDetachedHead or detached HEAD message", err.Error())
 	}
 }

--- a/internal/core/worktree_state.go
+++ b/internal/core/worktree_state.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+)
+
+type WorktreeState struct {
+	Entries       []gitx.Worktree
+	CurrentBranch string
+}
+
+func (s *Service) WorktreeState(commandCtx context.Context) (*WorktreeState, error) {
+	if commandCtx == nil {
+		return nil, fmt.Errorf("missing command context")
+	}
+
+	entries, err := gitx.ListWorktrees(commandCtx, s.Ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	current, err := gitx.CurrentBranch(commandCtx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorktreeState{
+		Entries:       entries,
+		CurrentBranch: current,
+	}, nil
+}
+
+func (s *Service) CurrentBranch(commandCtx context.Context) (string, error) {
+	if commandCtx == nil {
+		return "", fmt.Errorf("missing command context")
+	}
+	return gitx.CurrentBranch(commandCtx, "")
+}

--- a/internal/core/worktree_state_test.go
+++ b/internal/core/worktree_state_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gbo-dev/feature-tree/internal/gitx"
+	"github.com/gbo-dev/feature-tree/internal/testutil"
+)
+
+func TestWorktreeStateReturnsEntriesAndCurrentBranch(t *testing.T) {
+	svc, _, _ := setupServiceWithFeatureWorktree(t)
+
+	entries, err := gitx.ListWorktrees(context.Background(), svc.Ctx)
+	if err != nil {
+		t.Fatalf("ListWorktrees returned error: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Branch == svc.Ctx.DefaultBranch {
+			testutil.Chdir(t, entry.Path)
+			break
+		}
+	}
+
+	state, err := svc.WorktreeState(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeState returned error: %v", err)
+	}
+	if len(state.Entries) < 2 {
+		t.Fatalf("WorktreeState returned %d entries, want at least 2", len(state.Entries))
+	}
+	if state.CurrentBranch != svc.Ctx.DefaultBranch {
+		t.Fatalf("WorktreeState current branch = %q, want %q", state.CurrentBranch, svc.Ctx.DefaultBranch)
+	}
+}
+
+func TestWorktreeStateDetachedHead(t *testing.T) {
+	svc, featurePath, _ := setupServiceWithFeatureWorktree(t)
+	testutil.Chdir(t, featurePath)
+
+	head := testutil.RunGit(t, featurePath, "rev-parse", "HEAD")
+	testutil.RunGit(t, featurePath, "checkout", "--detach", head)
+
+	_, err := svc.WorktreeState(context.Background())
+	if err == nil {
+		t.Fatalf("WorktreeState expected error on detached HEAD")
+	}
+	if !errors.Is(err, gitx.ErrDetachedHead) {
+		t.Fatalf("WorktreeState detached HEAD error = %v, want ErrDetachedHead", err)
+	}
+}
+
+func TestCurrentBranchRejectsNilContext(t *testing.T) {
+	svc := &Service{Ctx: &gitx.RepoContext{DefaultBranch: "main"}}
+	_, err := svc.CurrentBranch(nil)
+	if err == nil {
+		t.Fatalf("CurrentBranch expected error for nil context")
+	}
+}

--- a/internal/gitx/errors.go
+++ b/internal/gitx/errors.go
@@ -1,0 +1,5 @@
+package gitx
+
+import "errors"
+
+var ErrDetachedHead = errors.New("HEAD is detached")

--- a/internal/gitx/worktree.go
+++ b/internal/gitx/worktree.go
@@ -2,6 +2,7 @@ package gitx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -76,10 +77,28 @@ func ListWorktrees(commandCtx context.Context, ctx *RepoContext) ([]Worktree, er
 
 func CurrentBranch(commandCtx context.Context, dir string) (string, error) {
 	stdout, stderr, exitCode, runErr := RunGit(commandCtx, dir, "symbolic-ref", "--quiet", "--short", "HEAD")
-	if err := CommandError("resolve current branch", stderr, exitCode, runErr, "HEAD is detached"); err != nil {
-		return "", err
+	if runErr != nil {
+		return "", fmt.Errorf("resolve current branch: %w", runErr)
+	}
+	if exitCode != 0 {
+		if isDetachedHeadFailure(stderr, exitCode) {
+			return "", fmt.Errorf("resolve current branch: %w", ErrDetachedHead)
+		}
+		return "", CommandError("resolve current branch", stderr, exitCode, nil, "HEAD is detached")
 	}
 	return strings.TrimSpace(stdout), nil
+}
+
+func isDetachedHeadFailure(stderr string, exitCode int) bool {
+	if exitCode == 1 {
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(lower, "not a symbolic ref") || strings.Contains(lower, "detached")
+}
+
+func IsDetachedHead(err error) bool {
+	return errors.Is(err, ErrDetachedHead)
 }
 
 func BranchExistsLocal(commandCtx context.Context, ctx *RepoContext, branch string) (bool, error) {

--- a/internal/gitx/worktree_test.go
+++ b/internal/gitx/worktree_test.go
@@ -46,6 +46,17 @@ func TestWorktreeHelpersListAndBranchQueries(t *testing.T) {
 		t.Fatalf("CurrentBranch = %q, want %q", current, "main")
 	}
 
+	head := testutil.RunGit(t, mainWorktreePath, "rev-parse", "HEAD")
+	testutil.RunGit(t, mainWorktreePath, "checkout", "--detach", head)
+
+	_, err = CurrentBranch(context.Background(), mainWorktreePath)
+	if err == nil {
+		t.Fatalf("CurrentBranch expected error on detached HEAD")
+	}
+	if !IsDetachedHead(err) {
+		t.Fatalf("CurrentBranch detached HEAD error = %v, want ErrDetachedHead", err)
+	}
+
 	exists, err := BranchExistsLocal(context.Background(), repoCtx, "feature-worktree")
 	if err != nil {
 		t.Fatalf("BranchExistsLocal returned error: %v", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #61.

Several CLI paths owned git/repo decisions that belong in `core` or shared helpers:

- `list`, `create`, `switch`, `remove`, and `copy-include` called `gitx` directly for worktree/current-branch orchestration.
- Detached HEAD detection in `list` used brittle substring matching; other commands treated any `CurrentBranch` error as detached HEAD.
- `ft remove` fetched from origin in the CLI layer.
- Shell completion fell back to `context.Background()` without trying the root command context.

## Solution

- **`gitx`:** Add `ErrDetachedHead` sentinel; `CurrentBranch` returns `errors.Is`-compatible detached HEAD errors.
- **`core`:** Add `WorktreeState` and `CurrentBranch` entry points; move `FetchOrigin` into `RemoveWorktree` and return `FetchWarning` on `RemoveResult`.
- **`cli`:** Route picker/list/inference paths through `core`; add small error helpers for detached HEAD mapping, picker cancel, and write failures; improve completion context fallback to root command context.

## Testing

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- New tests: detached HEAD in `gitx`, `WorktreeState` in `core`, completion context selection in `cli`
- Existing integration tests for detached HEAD UX preserved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdee3ff5-effe-4e04-848c-a8e0c2abfc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdee3ff5-effe-4e04-848c-a8e0c2abfc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

